### PR TITLE
start adding ccolamd work for manipulating variable ordering

### DIFF
--- a/src/IncrementalInference.jl
+++ b/src/IncrementalInference.jl
@@ -23,6 +23,9 @@ using
   Optim # might be deprecated in favor for only NLsolve dependency
 
 
+include("ccolamd.jl")
+using Ccolamd
+
 const KDE = KernelDensityEstimate
 
 import Base: convert
@@ -214,7 +217,6 @@ export
 
 
 const NothingUnion{T} = Union{Nothing, T}
-
 
 include("FactorGraphTypes.jl")
 include("AliasScalarSampling.jl")

--- a/src/IncrementalInference.jl
+++ b/src/IncrementalInference.jl
@@ -23,8 +23,6 @@ using
   Optim # might be deprecated in favor for only NLsolve dependency
 
 
-include("ccolamd.jl")
-using Ccolamd
 
 const KDE = KernelDensityEstimate
 
@@ -217,6 +215,8 @@ export
 
 
 const NothingUnion{T} = Union{Nothing, T}
+
+include("ccolamd.jl")
 
 include("FactorGraphTypes.jl")
 include("AliasScalarSampling.jl")

--- a/src/ccolamd.jl
+++ b/src/ccolamd.jl
@@ -1,6 +1,7 @@
 module Ccolamd
 
-using Base.SparseArrays.CHOLMOD.SuiteSparse_long
+using SparseArrays
+using SuiteSparse.CHOLMOD: SuiteSparse_long
 
 const KNOBS = 20
 const STATS = 20


### PR DESCRIPTION
adding the working module, but still need to wire the method to replace current variable ordering extraction using `qr permute` method.