### PR TITLE
Updating API call for new signatures

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -85,9 +85,9 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[DiffEqDiffTools]]
 deps = ["LinearAlgebra", "SparseArrays", "StaticArrays"]
-git-tree-sha1 = "19add9fe03568da945997cd7052c3405b84d302f"
+git-tree-sha1 = "c83f4ce45d4b723f9d21b9ea3d314a503fd40def"
 uuid = "01453d9d-ee7c-5054-8395-0335cb756afa"
-version = "0.11.0"
+version = "0.12.0"
 
 [[DiffResults]]
 deps = ["Compat", "StaticArrays"]
@@ -113,9 +113,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DistributedFactorGraphs]]
 deps = ["DataFrames", "Dates", "Distributions", "DocStringExtensions", "Graphs", "JSON2", "Neo4j", "Reexport", "Requires"]
-git-tree-sha1 = "5b5d3ea58cb1b4e820ee55ebce295b8deefb4895"
+git-tree-sha1 = "dc17dd1a492e74fde6b8ecdf01a75ab710b406ea"
 uuid = "b5cc3c7e-6572-11e9-2517-99fb8daf2f04"
-version = "0.1.3"
+version = "0.2.0"
 
 [[Distributions]]
 deps = ["LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns"]

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
 ApproxManifoldProducts = "0.1, 0.2"
-DistributedFactorGraphs = "0.1.3"
+DistributedFactorGraphs = "0.2"
 Distributions = "≥ 0.18"
 DocStringExtensions = "≥ 0.7"
 FileIO = "≥ 1.0.2"

--- a/src/JunctionTree.jl
+++ b/src/JunctionTree.jl
@@ -317,10 +317,10 @@ Wipe data from `dfg` object so that a completely fresh Bayes/Junction/Eliminatio
 can be constructed.
 """
 function resetFactorGraphNewTree!(dfg::G)::Nothing where G <: AbstractDFG
-  for v in DFG.ls(dfg)
+  for v in DFG.getVariables(dfg)
     resetData!(getData(v))
   end
-  for f in DFG.lsf(dfg)
+  for f in DFG.getFactors(dfg)
     resetData!(getData(f))
   end
   nothing


### PR DESCRIPTION
This PR should address the API changes for DFG 0.1.4, where ls() and lsf() return `Vector{Symbols}` rather than `Vector{<:DFGNode}`.

There may be more changes required, but with this change batchSolve! can be run end-to-end on Hex example.