### PR TITLE
add tests for generateTexTree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.dot
 *.pdf
 src/tmpimgs/*.gif
+test/tmp/*.dot
+test/tmp/*.tex
 
 Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
     packages:
     - hdf5-tools
     - texlive-latex-base
+    - texlive-pictures
     - preview-latex-style
     - dot2tex
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
   apt:
     packages:
     - hdf5-tools
+    - texlive-latex-base
     - dot2tex
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
   apt:
     packages:
     - hdf5-tools
+    - texlive-latex-base
     - preview-latex-style
     - dot2tex
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
   apt:
     packages:
     - hdf5-tools
+    - dot2tex
 
 # script:
 #   - julia --color=yes -e 'using Pkg; Pkg.build()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
   apt:
     packages:
     - hdf5-tools
-    - texlive-latex-base
+    - preview-latex-style
     - dot2tex
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ addons:
     - hdf5-tools
     - dot2tex
 
+before_script:
+  - pip install dot2tex
+
 # script:
 #   - julia --color=yes -e 'using Pkg; Pkg.build()'
 #   - julia --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'

--- a/src/JunctionTree.jl
+++ b/src/JunctionTree.jl
@@ -268,7 +268,7 @@ Related:
 drawTree
 """
 function generateTexTree(treel::BayesTree;
-                         filepath::String="/tmp/caesar/bt")
+                         filepath::String="/tmp/caesar/bayes/bt")
     btc = deepcopy(treel)
     for (cid, cliq) in btc.cliques
         label = cliq.attributes["label"]
@@ -315,7 +315,7 @@ function generateTexTree(treel::BayesTree;
     # Use new labels to produce `.dot` and `.tex` files.
     fid = IOStream("")
     try
-        mkpath(filepath)
+        mkpath(joinpath((split(filepath,'/')[1:(end-1)])...) )
         fid = open("$(filepath).dot","w+")
         write(fid, to_dot(btc.bt))
         close(fid)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,8 @@ end
 # include("testExpandedJLD.jl")
 
 
+include("testTexTreeIllustration.jl")
+
 
 
 

--- a/test/testTexTreeIllustration.jl
+++ b/test/testTexTreeIllustration.jl
@@ -44,7 +44,7 @@ tree = wipeBuildNewTree!(fg)
 # drawTree(tree, show=true, imgs=false)
 
 # Now, let's generate the corresponding `.dot` and `.tex`.
-texTree = generateTexTree(tree)
+texTree = generateTexTree(tree, filepath=joinpath(@__DIR__,"tmp","bt"))
 
 # All you have to do now is compile your newly created `.tex` file, probably
 # include the `bm` package (`\usepackage{bm}`), and enjoy!

--- a/test/testTexTreeIllustration.jl
+++ b/test/testTexTreeIllustration.jl
@@ -1,0 +1,55 @@
+# Simple examples to illustrate how to obtain a Bayes (junction) tree using
+# with beautiful Tex labels in `.dot` and `.tex` format.
+
+using Test
+
+using IncrementalInference
+
+# EXPERIMENTAL FEATURE, 4Q19: need `sudo apt install dot2tex`
+import IncrementalInference: generateTexTree
+
+@testset "testing generateTexTree" begin
+
+# Create a dummy factor graph, with variables and constraints.
+fg = initfg()
+
+# Add four pose variables, with 'x' symbol.
+addVariable!(fg, :x1, ContinuousScalar)
+addVariable!(fg, :x2, ContinuousScalar)
+addVariable!(fg, :x3, ContinuousScalar)
+addVariable!(fg, :x4, ContinuousScalar)
+
+# Add two landmark variables, with 'l' symbol.
+addVariable!(fg, :l1, ContinuousScalar)
+addVariable!(fg, :l2, ContinuousScalar)
+
+# Add the pose chain constraints (odometry and priors).
+addFactor!(fg, [:x1], Prior(Normal()))
+addFactor!(fg, [:x1;:x2], LinearConditional(Normal()))
+addFactor!(fg, [:x2;:x3], LinearConditional(Normal()))
+addFactor!(fg, [:x3;:x4], LinearConditional(Normal()))
+
+# Add the pose-landmark constraints (range measurements)
+addFactor!(fg, [:x1;:l1], LinearConditional(Normal()))
+addFactor!(fg, [:x2;:l1], LinearConditional(Normal()))
+addFactor!(fg, [:x3;:l1], LinearConditional(Normal()))
+addFactor!(fg, [:x2;:l2], LinearConditional(Normal()))
+addFactor!(fg, [:x3;:l2], LinearConditional(Normal()))
+addFactor!(fg, [:x4;:l2], LinearConditional(Normal()))
+
+# Let's take a peek to see how our factor graph looks like.
+# drawGraph(fg, show=true)
+# As well as our tree (AMD ordering)
+tree = wipeBuildNewTree!(fg)
+# drawTree(tree, show=true, imgs=false)
+
+# Now, let's generate the corresponding `.dot` and `.tex`.
+texTree = generateTexTree(tree)
+
+# All you have to do now is compile your newly created `.tex` file, probably
+# include the `bm` package (`\usepackage{bm}`), and enjoy!
+
+# fake a count of 1, since we are actually testing generateTexTree
+@test true
+
+end  # testset


### PR DESCRIPTION
remains an experimental feature, that requires `dot2tex`

cc @tonioteran -- thanks for contributing!