### PR TITLE
attmept lang python for dot2tex support on arm64 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: julia
+language: 
+  - julia
+  - python
 
 os:
   - linux


### PR DESCRIPTION
https://travis-ci.community/t/pip-is-not-installed-in-ppc64le-and-arm64-images/5902