### PR TITLE
Additional updates to persist the values on initialization

### DIFF
--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -824,8 +824,10 @@ function doautoinit!(dfg::T,
         end
         pts,inferdim = predictbelief(dfg, vsym, useinitfct, logger=logger)
         setValKDE!(xi, pts, true, inferdim)
-        #TODO test
-        setVariablePosteriorEstimates!(xi)
+        # Update the estimates (longer DFG function used so cloud is also updated)
+        setVariablePosteriorEstimates!(dfg, xi.label)
+        # Update the data in the event that it's not local
+        mergeVariableSolverData!(dfg, xi)
         didinit = true
       end
     end

--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -827,7 +827,7 @@ function doautoinit!(dfg::T,
         # Update the estimates (longer DFG function used so cloud is also updated)
         setVariablePosteriorEstimates!(dfg, xi.label)
         # Update the data in the event that it's not local
-        mergeVariableSolverData!(dfg, xi)
+        updateVariableSolverData!(dfg, xi, :default)
         didinit = true
       end
     end

--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -830,7 +830,7 @@ function doautoinit!(dfg::T,
         updateVariableSolverData!(dfg, xi, :default)
         # deepcopy graphinit value
         graphinit_xi = deepcopy(xi)
-        updateVariableSolverData!(dfg, xi, :graphinit)  # see 612
+        updateVariableSolverData!(dfg, graphinit_xi, :graphinit)  # see 612
         didinit = true
       end
     end

--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -827,10 +827,9 @@ function doautoinit!(dfg::T,
         # Update the estimates (longer DFG function used so cloud is also updated)
         setVariablePosteriorEstimates!(dfg, xi.label)
         # Update the data in the event that it's not local
-        updateVariableSolverData!(dfg, xi, :default)
-        # deepcopy graphinit value
-        graphinit_xi = deepcopy(xi)
-        updateVariableSolverData!(dfg, graphinit_xi, :graphinit)  # see 612
+        updateVariableSolverData!(dfg, xi, :default, true)    # TODO perhaps usecopy=false
+        # deepcopy graphinit value, see IIF #612
+        updateVariableSolverData!(dfg, xi.label, getSolverData(xi, :default), :graphinit, true, Symbol[]) # TODO add verbose as false DFG v0.7.5
         didinit = true
       end
     end

--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -828,6 +828,9 @@ function doautoinit!(dfg::T,
         setVariablePosteriorEstimates!(dfg, xi.label)
         # Update the data in the event that it's not local
         updateVariableSolverData!(dfg, xi, :default)
+        # deepcopy graphinit value
+        graphinit_xi = deepcopy(xi)
+        updateVariableSolverData!(dfg, xi, :graphinit)  # see 612
         didinit = true
       end
     end


### PR DESCRIPTION
On initialization, persist the values - these should be no-ops for in-memory.