### PR TITLE
Update to fit with DFG #459 fixes to buildSubgraph function

### DIFF
--- a/src/CliqStateMachine.jl
+++ b/src/CliqStateMachine.jl
@@ -680,7 +680,7 @@ function buildCliqSubgraphForDown_StateMachine(csmc::CliqStateMachineContainer)
   # build a local subgraph for inference operations
   syms = getCliqAllVarIds(csmc.cliq)
   infocsm(csmc, "2r, build subgraph syms=$(syms)")
-  csmc.cliqSubFg = buildSubgraph(csmc.dfg, syms)
+  csmc.cliqSubFg = buildSubgraph(csmc.dfg, syms, 1)
 
   opts = getSolverParams(csmc.dfg)
   # store the cliqSubFg for later debugging

--- a/src/SubGraphFunctions.jl
+++ b/src/SubGraphFunctions.jl
@@ -175,7 +175,7 @@ function buildCliqSubgraphDown(fgl::AbstractDFG, treel::AbstractBayesTree, cliqs
   # build a subgraph copy of clique
   cliq = whichCliq(treel, cliqsym)
   syms = getCliqAllVarIds(cliq)
-  subfg = buildSubgraph(fgl,syms)
+  subfg = buildSubgraph(fgl, syms, 1)
 
   # add upward messages to subgraph
   msgs = getCliqParentMsgDown(treel, cliq)

--- a/src/TreeBasedInitialization.jl
+++ b/src/TreeBasedInitialization.jl
@@ -316,7 +316,7 @@ function condenseDownMsgsProductPrntFactors!(fgl::G,
   end
 
   # build required subgraph for parent/sibling down msgs
-  lsfg = buildSubgraph(fgl, lvarids)
+  lsfg = buildSubgraph(fgl, lvarids, 1)
 
   tempfcts = lsf(lsfg)
   dellist = setdiff(awfcts, tempfcts)

--- a/test/testCompareVariablesFactors.jl
+++ b/test/testCompareVariablesFactors.jl
@@ -90,7 +90,7 @@ addFactor!(fg, [:x1;:x2], LinearConditional(Normal(4.0, 0.1)))
 addVariable!(fg, :l1, ContinuousScalar)
 addFactor!(fg, [:x1;:l1], LinearConditional(Rayleigh()))
 
-sfg = buildSubgraph(fg, [:x0;:x1], 1) # distance=1 to include factors (should be the default DFG #442)
+sfg = buildSubgraph(fg, [:x0;:x1], 1) # distance=1 to include factors 
 
 #FIXME JT - this doesn't make sense to pass, it is a subgraph so should it not rather be ⊂ [subset]?
 # compareDFG(fg1, fg2, by=⊂, skip=...)


### PR DESCRIPTION
@dehann, we cannot have 2 defaults in the same API

Default is equivalent to old `getSubgraph`, with an optional distance it is equivalent to old `getSubgraphAroundNode`, also see [docs](https://juliarobotics.org/DistributedFactorGraphs.jl/latest/func_ref/#DistributedFactorGraphs.buildSubgraph-Union{Tuple{G},%20Tuple{Type{G},AbstractDFG,Array{Symbol,1}},%20Tuple{Type{G},AbstractDFG,Array{Symbol,1},Int64}}%20where%20G%3C:AbstractDFG)