### PR TITLE
remove misleading comment

### DIFF
--- a/src/TreeBasedInitialization.jl
+++ b/src/TreeBasedInitialization.jl
@@ -187,7 +187,7 @@ function condenseDownMsgsProductPrntFactors!(fgl::AbstractDFG,
   end
 
   # build required subgraph for parent/sibling down msgs
-  lsfg = buildSubgraph(fgl, lvarids, 1; verbose=false)#FIXME #852 don't try and copy orphans to start with
+  lsfg = buildSubgraph(fgl, lvarids, 1; verbose=false)
 
   tempfcts = lsf(lsfg)
   dellist = setdiff(awfcts, tempfcts)


### PR DESCRIPTION
relates to #852 .  Hi @Affie, think you misunderstanding whats happening here.  The design decision we all made was to keep DFGFactor immutable, but that means extracting a subgraph with only a list of variables must avoid orphaned factors -- the warning true by default is good enough to resolve that issue.  Lets please move on from this discussion, the subgraph consolidation is finalized for the foreseeable future.