### PR TITLE
Fix addLikelihoodsDifferential!

### DIFF
--- a/src/TreeMessageUtils.jl
+++ b/src/TreeMessageUtils.jl
@@ -144,15 +144,16 @@ DevNotes
 - Initial version which only works for Pose2 and Point2 at this stage.
 """
 function addLikelihoodsDifferential!(msgs::LikelihoodMessage,
-                                            tfg::AbstractDFG=initfg() )
+                                     tfg::AbstractDFG=initfg() )
   # create new local dfg and add all the variables with data
   listVarByDim = Symbol[]
   for (label, val) in msgs.belief
     push!(listVarByDim, label)
     if !exists(tfg, label)
       addVariable!(tfg, label, val.softtype)
-      initManual!(tfg, label, manikde!(val))
+      @debug "New variable added to subfg" _group=:check_addLHDiff #TODO JT remove debug. 
     end
+    initManual!(tfg, label, manikde!(val))
   end
 
   # list all variables in order of dimension size

--- a/test/testDefaultDeconv.jl
+++ b/test/testDefaultDeconv.jl
@@ -22,7 +22,8 @@ end
 
 msg = getMsgUpThis(tree.cliques[2])
 
-tfg = addLikelihoodsDifferential!(msg)
+tfg = buildCliqSubgraph(fg, tree.cliques[2])
+addLikelihoodsDifferential!(tfg, msg)
 
 # drawGraph(tfg, show=true)
 


### PR DESCRIPTION
fixes https://github.com/JuliaRobotics/IncrementalInference.jl/issues/913#issuecomment-699580458

```julia
using RoME
using RoMEPlotting
fg = generateCanonicalFG_Circle(6;graphinit=false)
fg.solverParams.useMsgLikelihoods = true
fg.solverParams.graphinit = false
fg.solverParams.treeinit = true
tree, smt, hist = solveTree!(fg)
p = RoMEPlotting.plotSLAM2D(fg)
```

![hex](https://user-images.githubusercontent.com/6612981/94370201-daeb4400-00ee-11eb-8340-a777222365f1.png)
