### PR TITLE
Rename softtype -> variableType, getSofttype -> getVariableType

### DIFF
--- a/src/AnalysisTools.jl
+++ b/src/AnalysisTools.jl
@@ -173,7 +173,7 @@ function mmdSolveKey(vari::DFGVariable,
   tstVal = getBelief(vari, tstKey)
 
   # calc mmd distance
-  mmd(refVal, tstVal, getSofttype(vari), bw=bw)
+  mmd(refVal, tstVal, getVariableType(vari), bw=bw)
 end
 
 

--- a/src/BeliefTypes.jl
+++ b/src/BeliefTypes.jl
@@ -39,7 +39,7 @@ struct TreeBelief{T <: InferenceVariable}
   val::Array{Float64,2}
   bw::Array{Float64,2}
   inferdim::Float64
-  softtype::T # rename to VariableType, DFG #603 
+  variableType::T # rename to VariableType, DFG #603 
   # TODO -- DEPRECATE
   manifolds::Tuple{Vararg{Symbol}} # NOTE added during #459 effort
   # only populated during up as solvableDims for each variable in clique, #910
@@ -47,31 +47,31 @@ struct TreeBelief{T <: InferenceVariable}
 end
 TreeBelief( p::BallTreeDensity,
             inferdim::Real=0,
-            softtype::T=ContinuousScalar(),
-            manifolds=getManifolds(softtype),
-            solvableDim::Real=0) where {T <: InferenceVariable} = TreeBelief{T}(getPoints(p), getBW(p), inferdim, softtype, manifolds, solvableDim)
+            variableType::T=ContinuousScalar(),
+            manifolds=getManifolds(variableType),
+            solvableDim::Real=0) where {T <: InferenceVariable} = TreeBelief{T}(getPoints(p), getBW(p), inferdim, variableType, manifolds, solvableDim)
 
 TreeBelief( val::Array{Float64,2},
             bw::Array{Float64,2},
             inferdim::Real=0,
-            softtype::T=ContinuousScalar(),
-            manifolds=getManifolds(softtype),
-            solvableDim::Real=0) where {T <: InferenceVariable} = TreeBelief{T}(val, bw, inferdim, softtype, manifolds, solvableDim)
+            variableType::T=ContinuousScalar(),
+            manifolds=getManifolds(variableType),
+            solvableDim::Real=0) where {T <: InferenceVariable} = TreeBelief{T}(val, bw, inferdim, variableType, manifolds, solvableDim)
 
 function TreeBelief(vnd::VariableNodeData, solvDim::Real=0)
-  TreeBelief( vnd.val, vnd.bw, vnd.inferdim, getSofttype(vnd), getManifolds(vnd), solvDim )
+  TreeBelief( vnd.val, vnd.bw, vnd.inferdim, getVariableType(vnd), getManifolds(vnd), solvDim )
 end
 
 TreeBelief(vari::DFGVariable, solveKey::Symbol=:default; solvableDim::Real=0) = TreeBelief( getSolverData(vari, solveKey) , solvableDim)
 
-getManifolds(treeb::TreeBelief) = getManifolds(treeb.softtype)
+getManifolds(treeb::TreeBelief) = getManifolds(treeb.variableType)
 
 function compare(t1::TreeBelief, t2::TreeBelief)
   TP = true
   TP = TP && norm(t1.val - t2.val) < 1e-5
   TP = TP && norm(t1.bw - t2.bw) < 1e-5
   TP = TP && abs(t1.inferdim - t2.inferdim) < 1e-5
-  TP = TP && t1.softtype == t2.softtype
+  TP = TP && t1.variableType == t2.variableType
   TP = TP && abs(t1.solvableDim - t2.solvableDim) < 1e-5
   return TP
 end

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -85,6 +85,22 @@ end
 
 @deprecate evalFactor2(w...;kw...) evalFactor(w...;kw...)
 
+# TreeBelief field softtype->variableType rename
+function Base.getproperty(x::TreeBelief,f::Symbol)
+  if f == :softtype
+    Base.depwarn("`TreeBelief` field `softtype` is deprecated, use `variableType`", :getproperty)
+    f = :variableType
+  end
+  getfield(x,f)
+end
+
+function Base.setproperty!(x::TreeBelief, f::Symbol, val)
+  if f == :softtype
+    Base.depwarn("`TreeBelief` field `softtype` is deprecated, use `variableType`", :getproperty)
+    f = :variableType
+  end
+  return setfield!(x, f, convert(fieldtype(typeof(x), f), val))
+end
 
 ##==============================================================================
 ## Deprecate at v0.18 

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -61,7 +61,7 @@ function findRelatedFromPotential(dfg::AbstractDFG,
   Npoints = size(ptsbw,2)
   # Assume we only have large particle population sizes, thanks to addNode!
   manis = getManifolds(dfg, varid)
-  # manis = getSofttype(DFG.getVariable(dfg, varid)).manifolds # older
+  # manis = getVariableType(DFG.getVariable(dfg, varid)).manifolds # older
   p = AMP.manikde!(ptsbw, manis)
   if Npoints != N # this is where we control the overall particle set size
       p = resample(p,N)

--- a/src/DispatchPackedConversions.jl
+++ b/src/DispatchPackedConversions.jl
@@ -62,7 +62,7 @@ completely rebuild the factor's CCW and user data.
 function rebuildFactorMetadata!(dfg::AbstractDFG{SolverParams}, factor::DFGFactor)
   # Set up the neighbor data
   neighbors = map(vId->getVariable(dfg, vId), getNeighbors(dfg, factor))
-  neighborUserData = map(v->getSolverData(v).softtype, neighbors)
+  neighborUserData = map(v->getSolverData(v).variableType, neighbors)
 
   # Rebuilding the CCW
   fsd = getSolverData(factor)

--- a/src/DispatchPackedConversions.jl
+++ b/src/DispatchPackedConversions.jl
@@ -62,7 +62,7 @@ completely rebuild the factor's CCW and user data.
 function rebuildFactorMetadata!(dfg::AbstractDFG{SolverParams}, factor::DFGFactor)
   # Set up the neighbor data
   neighbors = map(vId->getVariable(dfg, vId), getNeighbors(dfg, factor))
-  neighborUserData = map(v->getSolverData(v).variableType, neighbors)
+  neighborUserData = map(v->getVariableType(v), neighbors)
 
   # Rebuilding the CCW
   fsd = getSolverData(factor)

--- a/src/FGOSUtils.jl
+++ b/src/FGOSUtils.jl
@@ -31,9 +31,9 @@ manikde!(pts::AbstractArray{Float64,1}, vartype::Type{ContinuousScalar}) = manik
 # extend convenience function
 function manikde!(pts::AbstractArray{Float64,2},
   bws::Vector{Float64},
-  softtype::Union{InstanceType{InferenceVariable}, InstanceType{FunctorInferenceType}}  )
+  variableType::Union{InstanceType{InferenceVariable}, InstanceType{FunctorInferenceType}}  )
 #
-manikde!(pts, bws, getManifolds(softtype))
+manikde!(pts, bws, getManifolds(variableType))
 end
 
 
@@ -56,7 +56,7 @@ Get graph node (variable or factor) dimension.
 """
 getDimension(vartype::InferenceVariable) = vartype.dims #TODO Deprecate
 getDimension(vartype::Type{<:InferenceVariable}) = getDimension(vartype())
-getDimension(var::DFGVariable) = getDimension(getSofttype(var))
+getDimension(var::DFGVariable) = getDimension(getVariableType(var))
 getDimension(fct::DFGFactor) = getSolverData(fct).fnc.zDim
 
 """
@@ -165,7 +165,7 @@ function calcPPE( var::DFGVariable,
 end
 
 
-calcPPE(var::DFGVariable; method::Type{<:AbstractPointParametricEst}=MeanMaxPPE, solveKey::Symbol=:default) = calcPPE(var, getSofttype(var), method=method, solveKey=solveKey)
+calcPPE(var::DFGVariable; method::Type{<:AbstractPointParametricEst}=MeanMaxPPE, solveKey::Symbol=:default) = calcPPE(var, getVariableType(var), method=method, solveKey=solveKey)
 
 """
     $TYPEDSIGNATURES
@@ -188,7 +188,7 @@ function calcPPE( dfg::AbstractDFG,
                   method::Type{<:AbstractPointParametricEst}=MeanMaxPPE )
   #
   var = getVariable(dfg, label)
-  calcPPE(var, getSofttype(var), method=method, solveKey=solveKey)
+  calcPPE(var, getVariableType(var), method=method, solveKey=solveKey)
 end
 
 const calcVariablePPE = calcPPE

--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -616,7 +616,7 @@ function prepgenericconvolution(
     ccw.cpt[i].factormetadata.variableuserdata = []
     ccw.cpt[i].factormetadata.solvefor = :null
     for xi in Xi
-      push!(ccw.cpt[i].factormetadata.variableuserdata, getSolverData(xi).variableType)
+      push!(ccw.cpt[i].factormetadata.variableuserdata, getVariableType(xi))
     end
   end
   return ccw

--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -6,7 +6,7 @@ reshapeVec2Mat(vec::Vector, rows::Int) = reshape(vec, rows, round(Int,length(vec
     $SIGNATURES
 Return the manifolds on which variable `sym::Symbol` is defined.
 """
-getManifolds(vd::VariableNodeData) = getSofttype(vd) |> getManifolds
+getManifolds(vd::VariableNodeData) = getVariableType(vd) |> getManifolds
 getManifolds(v::DFGVariable; solveKey::Symbol=:default) = getManifolds(getSolverData(v, solveKey))
 function getManifolds(dfg::G, sym::Symbol; solveKey::Symbol=:default) where {G <: AbstractDFG}
   return getManifolds(getVariable(dfg, sym), solveKey=solveKey)
@@ -135,8 +135,8 @@ function setValKDE!(vd::VariableNodeData,
                     val::Array{Float64,2},
                     setinit::Bool=true,
                     inferdim::Float64=0.0)::Nothing
-  # recover softtype information
-  sty = getSofttype(vd)
+  # recover variableType information
+  sty = getVariableType(vd)
   p = AMP.manikde!(val, getManifolds(sty))
   setValKDE!(vd, p, setinit, inferdim)
   nothing
@@ -148,7 +148,7 @@ function setValKDE!(v::DFGVariable,
                     setinit::Bool=true,
                     inferdim::Float64=0;
                     solveKey::Symbol=:default)::Nothing
-  # recover softtype information
+  # recover variableType information
   setValKDE!(getSolverData(v, solveKey), val, bws[:,1], setinit, inferdim )
 
   nothing
@@ -159,7 +159,7 @@ function setValKDE!(v::DFGVariable,
                     setinit::Bool=true,
                     inferdim::Float64=0.0;
                     solveKey::Symbol=:default)::Nothing
-  # recover softtype information
+  # recover variableType information
   setValKDE!(getSolverData(v, solveKey),val, setinit, inferdim )
   nothing
 end
@@ -264,14 +264,14 @@ end
 
 function DefaultNodeDataParametric(dodims::Int,
                                    dims::Int,
-                                   softtype::InferenceVariable;
+                                   variableType::InferenceVariable;
                                    initialized::Bool=true,
                                    dontmargin::Bool=false)::VariableNodeData
 
   # this should be the only function allocating memory for the node points
   if false && initialized
     error("not implemented yet")
-    # pN = AMP.manikde!(randn(dims, N), softtype.manifolds);
+    # pN = AMP.manikde!(randn(dims, N), variableType.manifolds);
     #
     # sp = Int[0;] #round.(Int,range(dodims,stop=dodims+dims-1,length=dims))
     # gbw = getBW(pN)[:,1]
@@ -281,18 +281,18 @@ function DefaultNodeDataParametric(dodims::Int,
     # #initval, stdev
     # return VariableNodeData(pNpts,
     #                         gbw2, Symbol[], sp,
-    #                         dims, false, :_null, Symbol[], softtype, true, 0.0, false, dontmargin)
+    #                         dims, false, :_null, Symbol[], variableType, true, 0.0, false, dontmargin)
   else
     sp = round.(Int,range(dodims,stop=dodims+dims-1,length=dims))
     return VariableNodeData(zeros(dims, 1),
                             zeros(dims,1), Symbol[], sp,
-                            dims, false, :_null, Symbol[], softtype, false, 0.0, false, dontmargin, 0, 0, :parametric)
+                            dims, false, :_null, Symbol[], variableType, false, 0.0, false, dontmargin, 0, 0, :parametric)
   end
 
 end
 
-function setDefaultNodeDataParametric!(v::DFGVariable, softtype::InferenceVariable; kwargs...)
-  vnd = DefaultNodeDataParametric(0, softtype |> getDimension, softtype; kwargs...)
+function setDefaultNodeDataParametric!(v::DFGVariable, variableType::InferenceVariable; kwargs...)
+  vnd = DefaultNodeDataParametric(0, variableType |> getDimension, variableType; kwargs...)
   setSolverData!(v, vnd, :parametric)
   return nothing
 end
@@ -367,7 +367,7 @@ function setVariableRefence!(dfg::AbstractDFG,
                          false,
                          :_null,
                          Symbol[],
-                         getSofttype(var),
+                         getVariableType(var),
                          true,
                          0.0,
                          false,
@@ -616,7 +616,7 @@ function prepgenericconvolution(
     ccw.cpt[i].factormetadata.variableuserdata = []
     ccw.cpt[i].factormetadata.solvefor = :null
     for xi in Xi
-      push!(ccw.cpt[i].factormetadata.variableuserdata, getSolverData(xi).softtype)
+      push!(ccw.cpt[i].factormetadata.variableuserdata, getSolverData(xi).variableType)
     end
   end
   return ccw
@@ -906,7 +906,7 @@ function initManual!( dfg::AbstractDFG,
   @info "initManual! $label"
   pts = predictbelief(dfg, label, usefcts)[1]
   vert = getVariable(dfg, label)
-  Xpre = AMP.manikde!(pts, getSofttype(vert) |> getManifolds )
+  Xpre = AMP.manikde!(pts, getVariableType(vert) |> getManifolds )
   setValKDE!(vert, Xpre, true)
   return nothing
 end
@@ -1332,7 +1332,7 @@ end
 
 Get KernelDensityEstimate kde estimate stored in variable node.
 """
-getBelief(vnd::VariableNodeData) = AMP.manikde!(getVal(vnd), getBW(vnd)[:,1], getSofttype(vnd) |> getManifolds)
+getBelief(vnd::VariableNodeData) = AMP.manikde!(getVal(vnd), getBW(vnd)[:,1], getVariableType(vnd) |> getManifolds)
 getBelief(v::DFGVariable, solvekey::Symbol=:default) = getKDE(getSolverData(v, solvekey))
 getBelief(dfg::AbstractDFG, lbl::Symbol, solvekey::Symbol=:default) = getKDE(getVariable(dfg, lbl), solvekey)
 

--- a/src/GraphProductOperations.jl
+++ b/src/GraphProductOperations.jl
@@ -91,7 +91,7 @@ function productbelief( dfg::AbstractDFG,
                         logger=ConsoleLogger()  )
   #
   vert = DFG.getVariable(dfg, vertlabel)
-  manis = getSofttype(vert) |> getManifolds
+  manis = getVariableType(vert) |> getManifolds
   pGM = Array{Float64,2}(undef, 0,0)
   lennonp, lenpart = length(dens), length(partials)
   if lennonp > 1
@@ -278,7 +278,7 @@ function localProduct(dfg::AbstractDFG,
   # take the product
   pGM = productbelief(dfg, sym, dens, partials, N, dbg=dbg, logger=logger )
   vari = DFG.getVariable(dfg, sym)
-  pp = AMP.manikde!(pGM, getSofttype(vari) |> getManifolds )
+  pp = AMP.manikde!(pGM, getVariableType(vari) |> getManifolds )
 
   return pp, dens, partials, lb, sum(inferdim)
 end

--- a/src/InferDimensionUtils.jl
+++ b/src/InferDimensionUtils.jl
@@ -31,7 +31,7 @@ Related
 
 getVariableInferredDim, getVariableInferredDimFraction
 """
-getVariableDim(vard::VariableNodeData)::Int = getSofttype(vard) |> getDimension
+getVariableDim(vard::VariableNodeData)::Int = getVariableType(vard) |> getDimension
 getVariableDim(var::DFGVariable)::Int = getVariableDim(getSolverData(var))
 
 """

--- a/src/ParametricCSMFunctions.jl
+++ b/src/ParametricCSMFunctions.jl
@@ -171,7 +171,7 @@ function solveDown_ParametricStateMachine(csmc::CliqStateMachineContainer)
   for fi in cliqFrontalVarIds
     vnd = getSolverData(getVariable(csmc.cliqSubFg, fi), :parametric)
     beliefMsg.belief[fi] = TreeBelief(vnd)
-    # beliefMsg.belief[fi] = TreeBelief(vnd.val, vnd.bw, vnd.inferdim, vnd.softtype.manifolds)
+    # beliefMsg.belief[fi] = TreeBelief(vnd.val, vnd.bw, vnd.inferdim, vnd.variableType.manifolds)
     logCSM(csmc, "$(csmc.cliq.id): down message $fi : $beliefMsg"; loglevel=Logging.Info)
   end
 

--- a/src/ParametricUtils.jl
+++ b/src/ParametricUtils.jl
@@ -314,7 +314,7 @@ end
 function MixedCircular(fg::AbstractDFG, varIds::Vector{Symbol})
   circMask = Bool[]
   for k = varIds
-    append!(circMask, getSofttype(fg, k) |> getManifolds .== :Circular)
+    append!(circMask, getVariableType(fg, k) |> getManifolds .== :Circular)
   end
   MixedCircular(circMask)
 end

--- a/src/SolveTree.jl
+++ b/src/SolveTree.jl
@@ -42,7 +42,7 @@ function compileFMCMessages(fgl::AbstractDFG,
     vari = DFG.getVariable(fgl,vsym)
     pden = getKDE(vari)
     bws = vec(getBW(pden)[:,1])
-    manis = getSofttype(vari) |> getManifolds
+    manis = getVariableType(vari) |> getManifolds
     d[vsym] = TreeBelief(vari) # getVal(vari), bws, manis, getSolverData(vari).inferdim
     with_logger(logger) do
       @info "fmcmc! -- getSolverData(vari=$(vari.label)).inferdim=$(getSolverData(vari).inferdim)"
@@ -70,7 +70,7 @@ function doFMCIteration(fgl::AbstractDFG,
     else
       # NOTE THIS PART IS DEPRECATED IN v0.16.0
       # we'd like to do this more pre-emptive and then just execute -- just point and skip up only msgs
-      densPts, potprod, inferdim = cliqGibbs(fgl, cliq, vsym, fmsgs, N, dbg, getSofttype(vert) |> getManifolds, logger)
+      densPts, potprod, inferdim = cliqGibbs(fgl, cliq, vsym, fmsgs, N, dbg, getVariableType(vert) |> getManifolds, logger)
     end
 
     if size(densPts,1)>0

--- a/src/TreeDebugTools.jl
+++ b/src/TreeDebugTools.jl
@@ -65,8 +65,8 @@ function treeProductUp(fg::AbstractDFG,
   #   dict = Dict{Symbol, TreeBelief}()
   #   for (dsy, btd) in msgdict.belief
   #     vari = getVariable(fg, dsy)
-  #     # manis = getSofttype(vari).manifolds
-  #     dict[dsy] = TreeBelief(btd.val, btd.bw, btd.inferdim, getSofttype(vari))
+  #     # manis = getVariableType(vari).manifolds
+  #     dict[dsy] = TreeBelief(btd.val, btd.bw, btd.inferdim, getVariableType(vari))
   #   end
   #   push!( upmsgssym, LikelihoodMessage(beliefDict=dict) )
   # end
@@ -75,7 +75,7 @@ function treeProductUp(fg::AbstractDFG,
   # perform the actual computation
   potprod = nothing
   pGM, fulldim = predictbelief(fg, sym, :, N=N, dbg=dbg )
-  # manis = getSofttype(getVariable(fg, sym)) |> getManifolds
+  # manis = getVariableType(getVariable(fg, sym)) |> getManifolds
   # pGM, potprod, fulldim = cliqGibbs( fg, cliq, sym, upmsgssym, N, dbg, manis )
 
   return pGM, potprod
@@ -109,7 +109,7 @@ function treeProductDwn(fg::G,
   msgdict = getDwnMsgs(cl[1])
   dict = Dict{Int, TreeBelief}()
   for (dsy, btd) in msgdict
-      dict[fg.IDs[dsy]] = TreeBelief(btd.val, btd.bw, btd.inferdim, getSofttype(getVariable(fg,sym)) )
+      dict[fg.IDs[dsy]] = TreeBelief(btd.val, btd.bw, btd.inferdim, getVariableType(getVariable(fg,sym)) )
   end
   dwnmsgssym = LikelihoodMessage[LikelihoodMessage(dict);]
 

--- a/src/TreeMessageUtils.jl
+++ b/src/TreeMessageUtils.jl
@@ -10,7 +10,7 @@ export addLikelihoodsDifferential!
 
 
 
-convert(::Type{BallTreeDensity}, src::TreeBelief) = manikde!(src.val, src.bw[:,1], src.softtype)
+convert(::Type{BallTreeDensity}, src::TreeBelief) = manikde!(src.val, src.bw[:,1], src.variableType)
 
 """
     $(SIGNATURES)
@@ -94,7 +94,7 @@ function updateSubFgFromDownMsgs!(sfg::G,
   # update specific variables in sfg from msgs
   for (key,beldim) in dwnmsgs.belief
     if key in seps
-      setValKDE!(sfg, key, manikde!(beldim.val,beldim.bw[:,1],getManifolds(beldim.softtype)), false, beldim.inferdim)
+      setValKDE!(sfg, key, manikde!(beldim.val,beldim.bw[:,1],getManifolds(beldim.variableType)), false, beldim.inferdim)
     end
   end
 
@@ -104,7 +104,7 @@ end
 
 
 function generateMsgPrior(belief_::TreeBelief, ::NonparametricMessage)
-  kdePr = manikde!(belief_.val, belief_.bw[:,1], getManifolds(belief_.softtype))
+  kdePr = manikde!(belief_.val, belief_.bw[:,1], getManifolds(belief_.variableType))
   MsgPrior(kdePr, belief_.inferdim)
 end
 
@@ -140,7 +140,7 @@ function addLikelihoodsDifferential!( msgs::LikelihoodMessage,
   for (label, val) in msgs.belief
     push!(listVarByDim, label)
     if !exists(tfg, label)
-      addVariable!(tfg, label, val.softtype)
+      addVariable!(tfg, label, val.variableType)
       @debug "New variable added to subfg" _group=:check_addLHDiff #TODO JT remove debug. 
     end
     initManual!(tfg, label, manikde!(val))
@@ -194,7 +194,7 @@ function addLikelihoodPriorCommon!( subfg::AbstractDFG,
   i = 0
   for (label, val) in msgs.belief
     i += 1
-    dims[i] = getDimension(val.softtype)
+    dims[i] = getDimension(val.variableType)
     syms[i] = label
     biAdj[i] = ls(subfg, label) |> length
   end
@@ -575,7 +575,7 @@ function convertLikelihoodToVector( prntmsgs::Dict{Int, LikelihoodMessage};
     # with_logger(logger) do  #   @info "convertLikelihoodToVector -- msgcliqid=$msgcliqid, msgs.belief=$(collect(keys(msgs.belief)))"  # end
     for (msgsym, msg) in msgs.belief
       # re-initialize with new type
-      varType = typeof(msg.softtype)
+      varType = typeof(msg.variableType)
       # msgspervar = msgspervar !== nothing ? msgspervar : Dict{Symbol, Vector{TreeBelief{varType}}}()
       if !haskey(msgspervar, msgsym)
         # there will be an entire list...

--- a/test/testgraphpackingconverters.jl
+++ b/test/testgraphpackingconverters.jl
@@ -85,10 +85,10 @@ dat = getSolverData(getVariable(fg,:x1))
 pd = packVariableNodeData(dfg, dat)
 unpckd = unpackVariableNodeData(dfg, pd)
 
-@test compareFields(dat, unpckd, skip=[:softtype])
-@test compareFields(dat.softtype, unpckd.softtype)
-@test isa(dat.softtype, ContinuousScalar)
-@test isa(unpckd.softtype, ContinuousScalar)
+@test compareFields(dat, unpckd, skip=[:variableType])
+@test compareFields(dat.variableType, unpckd.variableType)
+@test isa(dat.variableType, ContinuousScalar)
+@test isa(unpckd.variableType, ContinuousScalar)
 
 end
 

--- a/test/testgraphpackingconverters.jl
+++ b/test/testgraphpackingconverters.jl
@@ -86,9 +86,9 @@ pd = packVariableNodeData(dfg, dat)
 unpckd = unpackVariableNodeData(dfg, pd)
 
 @test compareFields(dat, unpckd, skip=[:variableType])
-@test compareFields(dat.variableType, unpckd.variableType)
-@test isa(dat.variableType, ContinuousScalar)
-@test isa(unpckd.variableType, ContinuousScalar)
+@test compareFields(getVariableType(dat), getVariableType(unpckd))
+@test isa(getVariableType(dat), ContinuousScalar)
+@test isa(getVariableType(unpckd), ContinuousScalar)
 
 end
 


### PR DESCRIPTION
This PR 
- makes use of `getVariableType` from DFG instead of `getSofttype` and `.softtype`
- renames and deprecates `TreeBelief` field `softtype` for `variableType`