### PR TITLE
Allow dispatch on cliq id vs graph index by using CliqueId

### DIFF
--- a/src/CliqueTypes.jl
+++ b/src/CliqueTypes.jl
@@ -251,7 +251,6 @@ function Base.setproperty!(x::TreeClique, f::Symbol, val)
   return setfield!(x, f, convert(fieldtype(typeof(x), f), val))
 end
 
-@deprecate TreeClique(i::Int, label::Union{AbstractString, Symbol}) TreeClique(CliqueId(i), BayesTreeNodeData(), Dict{String,Any}())
 TreeClique(i::Int) = TreeClique(CliqueId(i), BayesTreeNodeData(), Dict{String,Any}())
 TreeClique(id::CliqueId) = TreeClique(id, BayesTreeNodeData(), Dict{String,Any}())
 

--- a/src/CliqueTypes.jl
+++ b/src/CliqueTypes.jl
@@ -209,6 +209,14 @@ end
 ## Cliques
 ## TreeClique
 ##==============================================================================
+struct CliqueId{T}
+  value::T
+end
+
+Base.getindex(cId::CliqueId) = cId.value
+Base.show(io::IO, ::MIME"text/plain", x::CliqueId) = print(io, x.value)
+Base.show(io::IO, x::CliqueId) = print(io, x.value)
+
 """
     $(TYPEDEF)
 Structure to store clique data
@@ -217,9 +225,7 @@ DEV NOTES: To replace TreeClique completely
 """
 mutable struct TreeClique
   "Interger id unique within a tree with userId, robotId, sessionId"
-  id::Int # not to be confused with the underlying index used by LightGraphs.jl, see issue #540
-  "This is currently a label such as `clique 1`"
-  label::Symbol #TODO maybe deprecated? # The drawing label is saved in attributes, JT I'm not sure of the current use
+  id::CliqueId{Int64} # not to be confused with the underlying index used by LightGraphs.jl, see issue #540
   "Data as `BayesTreeNodeData`"
   data::BayesTreeNodeData 
   "Drawing attributes"
@@ -245,11 +251,11 @@ function Base.setproperty!(x::TreeClique, f::Symbol, val)
   return setfield!(x, f, convert(fieldtype(typeof(x), f), val))
 end
 
-TreeClique(i::Int, label::Symbol) = TreeClique(i, label, BayesTreeNodeData(), Dict{String,Any}())
-TreeClique(i::Int, label::AbstractString) = TreeClique(i, Symbol(label))
+@deprecate TreeClique(i::Int, label::Union{AbstractString, Symbol}) TreeClique(CliqueId(i), BayesTreeNodeData(), Dict{String,Any}())
+TreeClique(i::Int) = TreeClique(CliqueId(i), BayesTreeNodeData(), Dict{String,Any}())
+TreeClique(id::CliqueId) = TreeClique(id, BayesTreeNodeData(), Dict{String,Any}())
 
 
-#TODO the label field and label attribute is a bit confusing with accessors.
 DFG.getLabel(cliq::TreeClique) = cliq.attributes["label"]
 function setLabel!(cliq::TreeClique, lbl::String)
   cliq.attributes["label"] = lbl

--- a/src/CompareUtils.jl
+++ b/src/CompareUtils.jl
@@ -27,7 +27,6 @@ function compare(c1::TreeClique,
 #
 TP = true
 TP = TP && c1.id == c2.id
-TP = TP && c1.label == c2.label
 # data
 @warn "skipping ::TreeClique compare of data"
 # TP = TP && compare(c1.data, c2.data)

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -83,6 +83,18 @@ end
 ## Deprecate at v0.19
 ##==============================================================================
 
+@deprecate getDwnMsgConsolidated(tree::AbstractBayesTree, edge) getMsgDwnChannel(tree, edge)
+
+# @deprecate putBeliefMessageUp!(tree::AbstractBayesTree, edge, beliefMsg::LikelihoodMessage) putMessageUp!(tree, edge, beliefMsg)
+# @deprecate takeBeliefMessageUp!(tree::AbstractBayesTree, edge) takeMessageUp!(tree, edge)
+# @deprecate putBeliefMessageDown!(tree::BayesTree, edge, beliefMsg::LikelihoodMessage) putMessageDown!(tree, edge, beliefMsg)
+# @deprecate takeBeliefMessageDown!(tree::BayesTree, edge) takeMessageDown!(tree, edge)
+
+@deprecate appendSeparatorToClique(w...;kw...) appendSeparatorToClique!(w...;kw...)
+
+@deprecate TreeClique(i::Int, label::Union{AbstractString, Symbol}) TreeClique(CliqueId(i), BayesTreeNodeData(), Dict{String,Any}())
+
+@deprecate emptyBayesTree() BayesTree()
 
 # Graph.jl does not have an in_edges function for a GenericIncidenceList, so extending here.
 # function Graphs.in_edges(vert::V, gr::GenericIncidenceList{V, Edge{V}, Vector{V}}) where {V}

--- a/src/JunctionTree.jl
+++ b/src/JunctionTree.jl
@@ -198,9 +198,6 @@ function appendSeparatorToClique!(bt::AbstractBayesTree, clqID::CliqueId, seprID
   nothing
 end
 
-# FIXME, move Deprecated.jl
-@deprecate appendSeparatorToClique(w...;kw...) appendSeparatorToClique!(w...;kw...)
-
 """
     $SIGNATURES
 

--- a/src/JunctionTree.jl
+++ b/src/JunctionTree.jl
@@ -3,6 +3,7 @@ export getCliquePotentials
 export getClique, getCliques, getCliqueIds, getCliqueData
 export hasClique
 export setCliqueDrawColor!, getCliqueDrawColor
+export appendSeparatorToClique!
 
 """
     $SIGNATURES
@@ -192,10 +193,13 @@ end
 
 Add the separator for the newly created clique.
 """
-function appendSeparatorToClique(bt::AbstractBayesTree, clqID::CliqueId, seprIDs::Array{Symbol,1})
+function appendSeparatorToClique!(bt::AbstractBayesTree, clqID::CliqueId, seprIDs::Array{Symbol,1})
   union!(getCliqueData(bt, clqID).separatorIDs, seprIDs)
   nothing
 end
+
+# FIXME, move Deprecated.jl
+@deprecate appendSeparatorToClique(w...;kw...) appendSeparatorToClique!(w...;kw...)
 
 """
     $SIGNATURES

--- a/src/JunctionTreeTypes.jl
+++ b/src/JunctionTreeTypes.jl
@@ -1,5 +1,5 @@
 
-export BayesTree
+export MetaBayesTree, BayesTree
 
 ## ========================================================================================================================
 ## Bayes Trees
@@ -7,9 +7,6 @@ export BayesTree
 
 abstract type AbstractBayesTree end
 
-emptyBayesTree() = MetaBayesTree()
-
-const BayesTree = MetaBayesTree
 
 # TODO DEV MetaGraphs bayes tree, will potentially also make a LightBayesTree, CloudBayesTree,
 """
@@ -23,6 +20,8 @@ mutable struct MetaBayesTree <: AbstractBayesTree
   variableOrder::Vector{Symbol}
   buildTime::Float64
 end
+
+const BayesTree = MetaBayesTree
 
 MetaBayesTree() = MetaBayesTree(MetaDiGraph{Int,Float64}(), 0, Dict{AbstractString, Int}(), Symbol[], 0.0)
 

--- a/src/JunctionTreeTypes.jl
+++ b/src/JunctionTreeTypes.jl
@@ -1,3 +1,6 @@
+
+export BayesTree
+
 ## ========================================================================================================================
 ## Bayes Trees
 ## ========================================================================================================================
@@ -5,6 +8,8 @@
 abstract type AbstractBayesTree end
 
 emptyBayesTree() = MetaBayesTree()
+
+const BayesTree = MetaBayesTree
 
 # TODO DEV MetaGraphs bayes tree, will potentially also make a LightBayesTree, CloudBayesTree,
 """

--- a/src/TreeMessageAccessors.jl
+++ b/src/TreeMessageAccessors.jl
@@ -84,11 +84,6 @@ function takeBeliefMessageUp!(tree::AbstractBayesTree, edge)
   return beliefMsg
 end
 
-# @deprecate putBeliefMessageUp!(tree::AbstractBayesTree, edge, beliefMsg::LikelihoodMessage) putMessageUp!(tree, edge, beliefMsg)
-# @deprecate takeBeliefMessageUp!(tree::AbstractBayesTree, edge) takeMessageUp!(tree, edge)
-# @deprecate putBeliefMessageDown!(tree::BayesTree, edge, beliefMsg::LikelihoodMessage) putMessageDown!(tree, edge, beliefMsg)
-# @deprecate takeBeliefMessageDown!(tree::BayesTree, edge) takeMessageDown!(tree, edge)
-
 ## ----------------------------------------------------------------------------- 
 ## DOWN
 ## ----------------------------------------------------------------------------- 
@@ -97,8 +92,6 @@ $SIGNATURES
 Get the message channel
 """
 getMsgDwnChannel(tree::MetaBayesTree, edge) = MetaGraphs.get_prop(tree.bt, edge, :downMsg)
-
-@deprecate getDwnMsgConsolidated(tree::AbstractBayesTree, edge) getMsgDwnChannel(tree, edge)
 
 """
     $SIGNATURES

--- a/test/testSphere1.jl
+++ b/test/testSphere1.jl
@@ -4,6 +4,7 @@ using Test
 @testset "test Sphere1D" begin
 
 fg = initfg()
+getSolverParams(fg).useMsgLikelihoods = true
 
 addVariable!.(fg, [Symbol("x$i") for i=0:4], Sphere1)
 addFactor!(fg, [:x0], PriorSphere1(Normal(0.0,0.1)))

--- a/test/testTreeFunctions.jl
+++ b/test/testTreeFunctions.jl
@@ -39,7 +39,7 @@ IIF.deleteClique!(oldtree, IIF.CliqueId(1))
 
 tree, smt, hists = solveTree!(fg, oldtree; smtasks=smtasks, verbose=false, recordcliqs=ls(fg));
 
-csmAnimate(tree, hists, frames=1)
+# csmAnimate(tree, hists, frames=1)
 
 end
   

--- a/test/testTreeFunctions.jl
+++ b/test/testTreeFunctions.jl
@@ -20,14 +20,26 @@ fg = generateCanonicalFG_lineStep(3;
 # getSolverParams(fg).showtree = true
 
 smtasks = Task[]
-oldtree, smt, hists = solveTree!(fg; smtasks=smtasks, verbose=true, recordcliqs=ls(fg));
+oldtree, smt, hists = solveTree!(fg; smtasks=smtasks, verbose=false, recordcliqs=ls(fg));
 
-IIF.deleteClique!(oldtree, 1)
+@test IIF.isRoot(oldtree, IIF.CliqueId(1))
+@test IIF.isRoot(oldtree, IIF.getClique(oldtree,1))
+@test !IIF.isRoot(oldtree, IIF.CliqueId(2))
+@test !IIF.isRoot(oldtree, IIF.CliqueId(3))
+
+IIF.deleteClique!(oldtree, IIF.CliqueId(1))
+
+@test IIF.isRoot(oldtree, IIF.CliqueId(2))
+@test IIF.isRoot(oldtree, IIF.CliqueId(3))
+
+@test IIF.getClique(oldtree, :x0) == IIF.getClique(oldtree, IIF.CliqueId(3)) == IIF.getClique(oldtree, 1)
+@test IIF.getClique(oldtree, :x3) == IIF.getClique(oldtree, IIF.CliqueId(2)) == IIF.getClique(oldtree, 2)
+ 
 # drawTree(oldtree, show=true)
 
-tree, smt, hists = solveTree!(fg, oldtree; smtasks=smtasks, verbose=true, recordcliqs=ls(fg));
+tree, smt, hists = solveTree!(fg, oldtree; smtasks=smtasks, verbose=false, recordcliqs=ls(fg));
 
-# csmAnimate(tree, hists, frames=1)
+csmAnimate(tree, hists, frames=1)
 
 end
   


### PR DESCRIPTION
- cleanup deprecated fields `parentCliq` `childCliqs` from `CliqStateMachineContainer`
- change `cliqKey::Int` to  `cliqId::CliqueId{Int}` in `CliqStateMachineContainer`
- remove unused `TreeClique` label field 

This PR is towards having the Tree independent of the underlying graph technology as with DFG.

The idea is that CliqueId is the unique field as per #540