### PR TITLE
first test pass on CalcFactor (LinearRelative)

### DIFF
--- a/src/Factors/LinearRelative.jl
+++ b/src/Factors/LinearRelative.jl
@@ -37,26 +37,26 @@ getDomain(::InstanceType{LinearRelative{N,<:SamplableBelief}}) where N = Continu
 
 getSample(s::LinearRelative, N::Int=1) = (reshape(rand(s.Z,N),:,N), )
 
-function (s::LinearRelative)( res::AbstractArray{<:Real},
-                              userdata::FactorMetadata,
-                              idx::Int,
-                              meas::Tuple,
-                              X1::AbstractArray{<:Real,2},
-                              X2::AbstractArray{<:Real,2}  )
-  #
-  res[:] = meas[1][:,idx] - (X2[:,idx] - X1[:,idx])
-  nothing
-end
-
-# # new and simplified interface
-# function (s::CalcFactor{T,M,P,X})(res::AbstractVector{<:Real},
-#                                   noise_z,
-#                                   x1,
-#                                   x2  ) where {T<:LinearRelative,M,P<:Tuple,X<:AbstractVector}
+# function (s::LinearRelative)( res::AbstractArray{<:Real},
+#                               userdata::FactorMetadata,
+#                               idx::Int,
+#                               meas::Tuple,
+#                               X1::AbstractArray{<:Real,2},
+#                               X2::AbstractArray{<:Real,2}  )
 #   #
-#   res[:] = noise_z - (x2 - x1)
+#   res[:] = meas[1][:,idx] - (X2[:,idx] - X1[:,idx])
 #   nothing
 # end
+
+# new and simplified interface
+function (s::CalcFactor{<:LinearRelative,M,P,X})(res::AbstractVector{<:Real},
+                                  noise_z,
+                                  x1,
+                                  x2  ) where {M<:FactorMetadata,P<:Tuple,X<:AbstractVector}
+  #
+  res .= noise_z - (x2 - x1)
+  nothing
+end
 
 
 

--- a/src/Factors/Mixture.jl
+++ b/src/Factors/Mixture.jl
@@ -76,22 +76,24 @@ function getSample( s::Mixture{N_,F,S,T},
   smpls = smplLambda()
     # smpls = Array{Float64,2}(undef,s.dims,N)
   #out memory should be right size first
-  (length(s.labels) != N) && resize!(s, N)
+  length(s.labels) != N ? resize!(s, N) : nothing
   s.labels .= rand(s.diversity, N)
   for i in 1:N
     mixComponent = s.components[s.labels[i]]
     smpls[:,i] = rand(mixComponent,1)
   end
-  (smpls, s.labels)
+
+  # TODO only does first element of meas::Tuple at this stage, see #1099
+  (smpls, ) # s.labels
 end
 
 
-# should not be called in case of Prior
-(s::Mixture)( res::AbstractArray{<:Real},
-              fmd::FactorMetadata,
-              idx::Int,
-              meas::Tuple,
-              X... ) = s.mechanics(res, fmd, idx, meas, X...)
+# # should not be called in case of Prior
+# (s::Mixture)( res::AbstractArray{<:Real},
+#               fmd::FactorMetadata,
+#               idx::Int,
+#               meas::Tuple,
+#               X... ) = s.mechanics(res, fmd, idx, meas, X...)
 #
 
 

--- a/test/testMixtureLinearConditional.jl
+++ b/test/testMixtureLinearConditional.jl
@@ -1,7 +1,11 @@
 using IncrementalInference
 using Test
 
+##
+
 @testset "test packing of Mixture" begin
+
+##
 
 fg = initfg()
 addVariable!(fg, :x0, ContinuousScalar)
@@ -35,12 +39,16 @@ B = ManifoldBelief(Euclid, IIF._getCCW(f1_).usrfnc!.components.fancy )
 
 @test mmd(A,B) < 1e-6
 
+##
+
 end
 
 
 
 #
 @testset "test simple Mixture" begin
+
+##
 
 fg = initfg()
 
@@ -72,6 +80,8 @@ addFactor!(fg, [:x0,:x1], mlr)
 
 tree, smt, hist = solveTree!(fg)
 
+##
+
 btd = getBelief(getVariable(fg, :x0))
 @test isapprox(mean(getKDEfit(btd,distribution=Normal)), 0.0; atol=0.1) 
 
@@ -95,5 +105,7 @@ nfit_n = fit(Normal, pts_n)
 #   using RoMEPlotting
 #   plotKDE(fg, ls(fg))
 # end
+
+##
 
 end

--- a/test/testMixturePrior.jl
+++ b/test/testMixturePrior.jl
@@ -5,8 +5,11 @@
 using IncrementalInference
 using Test
 
+##
 
 @testset "test mixture prior" begin
+
+##
 
 # init graph
 fg = initfg()
@@ -37,10 +40,10 @@ saveDFG("/tmp/test_fg_bss", fg)
 
 
 # check numerics
-smpls, lb = getSample(Prior0, N)
+smpls, = getSample(Prior0, N) # ,lb=
 
 # should be a balance of particles
-@test sum(lb .== 1) - sum(lb .== 2) |> abs < 0.3*N
+# @test sum(lb .== 1) - sum(lb .== 2) |> abs < 0.3*N
 @test sum(smpls .< -2.5) - sum(-2.5 .< smpls) |> abs < 0.3*N
 
 # solve
@@ -51,6 +54,7 @@ marginalPts = getBelief(fg, :x0) |> getPoints
 # check solver solution consistent too
 @test sum(marginalPts .< -2.5) - sum(-2.5 .< marginalPts) |> abs < 0.3*N
 
+##
 
 end
 
@@ -58,6 +62,7 @@ end
 
 @testset "Serialization of Mixture(Prior,..) including a AliasingScalarSampler" begin
 
+##
 
 fg_ = loadDFG("/tmp/test_fg_bss")
 
@@ -75,6 +80,8 @@ marginalPts = getBelief(fg_, :x0) |> getPoints
 
 # cleanup
 Base.rm("/tmp/test_fg_bss.tar.gz")
+
+##
 
 end
 


### PR DESCRIPTION
Small breaking change where `getSample(::Mixture...)` no longer returns the selected component labels as second element in tuple.  See #1099 for more details. 