### PR TITLE
Fixes for plotCliqUpMsgs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "IncrementalInference"
 uuid = "904591bb-b899-562f-9e6f-b8df64c7d480"
 keywords = ["MM-iSAM", "MM-iSAMv2", "Bayes tree", "junction tree", "Bayes network", "variable elimination", "graphical models", "SLAM", "inference", "sum-product", "belief-propagation"]
 desc = "Implements the Multimodal iSAM algorithm."
-version = "0.21.0"
+version = "0.21.1"
 
 [deps]
 ApproxManifoldProducts = "9bbbb610-88a1-53cd-9763-118ce10c1f89"

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -274,7 +274,7 @@ end
 # figure out how to deprecate (not critical at the moment)
 # used in RoMEPlotting 
 # NOTE: TempUpMsgPlotting will be removed.
-# Replaced with: UpMsgPlotting = @NamedTuple{clidId::CliqueId{Int}, depth::Int, belief::TreeBelief}
+# Replaced with: UpMsgPlotting = @NamedTuple{cliqId::CliqueId{Int}, depth::Int, belief::TreeBelief}
 const TempUpMsgPlotting = Dict{Symbol,Vector{Tuple{Symbol, Int, BallTreeDensity, Float64}}}
 
 ##==============================================================================

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -271,6 +271,11 @@ end
 @deprecate solveFactorMeasurements( dfg::AbstractDFG,fctsym::Symbol,solveKey::Symbol=:default;retries::Int=3 ) approxDeconv(dfg,fctsym,solveKey,retries=retries)
 
 
+# figure out how to deprecate (not critical at the moment)
+# used in RoMEPlotting 
+# NOTE: TempUpMsgPlotting will be removed.
+# Replaced with: UpMsgPlotting = @NamedTuple{clidId::CliqueId{Int}, depth::Int, belief::TreeBelief}
+const TempUpMsgPlotting = Dict{Symbol,Vector{Tuple{Symbol, Int, BallTreeDensity, Float64}}}
 
 ##==============================================================================
 ## Deprecate code below before v0.21

--- a/src/Factors/MsgLikelihoods.jl
+++ b/src/Factors/MsgLikelihoods.jl
@@ -160,16 +160,3 @@ end
 ==(l1::LikelihoodMessage,l2::LikelihoodMessage) = compare(l1,l2)
 
 
-
-## =========================================================================================
-## DEPRECATE BELOW AS ABLE
-## =========================================================================================
-
-
-# figure out how to deprecate (not critical at the moment)
-# used in RoMEPlotting
-const TempUpMsgPlotting = Dict{Symbol,Vector{Tuple{Symbol, Int, BallTreeDensity, Float64}}}
-
-
-
-

--- a/src/TreeMessageUtils.jl
+++ b/src/TreeMessageUtils.jl
@@ -733,7 +733,6 @@ end
 ## Multimessage assemblies from multiple cliques 
 ## =============================================================================
 
-#TODO add test coverage
 """
     $SIGNATURES
 
@@ -749,10 +748,9 @@ function getTreeCliqUpMsgsAll(tree::AbstractBayesTree)
   return allUpMsgs
 end
 
-# TODO @NamedTuple{clidId::CliqueId{Int}, depth::Int, belief::TreeBelief}
-const UpMsgPlotting = NamedTuple{(:clidId, :depth, :belief), Tuple{CliqueId{Int}, Int, TreeBelief}}
+# TODO @NamedTuple{cliqId::CliqueId{Int}, depth::Int, belief::TreeBelief}
+const UpMsgPlotting = NamedTuple{(:cliqId, :depth, :belief), Tuple{CliqueId{Int}, Int, TreeBelief}}
 
-#TODO add test coverage
 """
     $SIGNATURES
 

--- a/src/TreeMessageUtils.jl
+++ b/src/TreeMessageUtils.jl
@@ -732,44 +732,27 @@ end
 ## =============================================================================
 ## Multimessage assemblies from multiple cliques 
 ## =============================================================================
-#TODO check as it looks outdated nothing covered after this
 
-
-#TODO function is currently broken as getUpMsgs does not exist, possibly deprecated?
-# DF, I did some digging and got this far
-# v0.14 @deprecate getUpMsgs(x...) getMsgsUpThis(x...)
-#       @deprecate getMsgsUpThis(x...) getMsgUpThis(x...)
-#         getMsgUpThis(cdat::BayesTreeNodeData) = fetch(getMsgUpChannel(cdat))
-# v0.16 @deprecate getMsgUpThis(x...;kw...) fetchMsgUpThis(x...;kw...)
-# fetchMsgUpThis was never properly deprecated, see #1053
+#TODO add test coverage
 """
     $SIGNATURES
 
 Return dictionary of all up belief messages currently in a Bayes `tree`.
 
-Notes
-- Returns `::Dict{Int,LikelihoodMessage}`
-
-DevNotes
-- see #1053, `getUpMsgs` --> `fetchMsgUpThis` v0.16
-
-Related
-
-getUpMsgs
 """
 function getTreeCliqUpMsgsAll(tree::AbstractBayesTree)
   allUpMsgs = Dict{Int,LikelihoodMessage}()
   for (idx,cliq) in getCliques(tree)
-    msgs = getUpMsgs(cliq)
-    allUpMsgs[cliq.id] = LikelihoodMessage()
-    for (lbl,msg) in msgs
-      # TODO capture the inferred dimension as part of the upward propagation
-      allUpMsgs[cliq.id].belief[lbl] = msg
-    end
+    msgs = getMessageBuffer(cliq).upRx
+    merge!(allUpMsgs, msgs)
   end
   return allUpMsgs
 end
 
+# TODO @NamedTuple{clidId::CliqueId{Int}, depth::Int, belief::TreeBelief}
+const UpMsgPlotting = NamedTuple{(:clidId, :depth, :belief), Tuple{CliqueId{Int}, Int, TreeBelief}}
+
+#TODO add test coverage
 """
     $SIGNATURES
 
@@ -777,35 +760,29 @@ Convert tree up messages dictionary to a new dictionary relative to variables sp
 
 Notes
 - Used in RoMEPlotting
-- Return data in `TempUpMsgPlotting` format:
-    Dict{Symbol,   -- is for variable label
-      Vector{       -- multiple msgs for the same variable
-        Symbol,      -- Clique index
-        Int,         -- Depth in tree
-        BTD          -- Belief estimate
-        inferredDim  -- Information count
-      }
+- Return data in `UpMsgPlotting` format.
 """
 function stackCliqUpMsgsByVariable( tree::AbstractBayesTree,
                                     tmpmsgs::Dict{Int, LikelihoodMessage}  )
   #
   # start of the return data structure
-  stack = TempUpMsgPlotting()
+  stack = Dict{Symbol,Vector{UpMsgPlotting}}()  
 
   # look at all the clique level data
   for (cidx,tmpmsg) in tmpmsgs
     # look at all variables up msg from each clique
-    for (sym,msgdim) in tmpmsg.belief
+    for (sym, belief) in tmpmsg.belief
       # create a new object for a particular variable if hasnt been seen before
       if !haskey(stack,sym)
         # FIXME this is an old message type
-        stack[sym] = Vector{Tuple{Symbol, Int, BallTreeDensity, Float64}}()
+        stack[sym] = Vector{UpMsgPlotting}()
       end
       # assemble metadata
       cliq = getClique(tree,cidx)
-      frt = getCliqFrontalVarIds(cliq)[1]
+      #TODO why was the first frontal used? i changed to clique id (unique)
+      # frt = getCliqFrontalVarIds(cliq)[1]
       # add this belief msg and meta data to vector of variable entry
-      push!(stack[sym], (frt, getCliqDepth(tree, cliq),msgdim[1], msgdim[2]))
+      push!(stack[sym], IIF.UpMsgPlotting((cliq.id, getCliqDepth(tree, cliq), belief)))
     end
   end
 
@@ -813,6 +790,7 @@ function stackCliqUpMsgsByVariable( tree::AbstractBayesTree,
 end
 
 
+#TODO check as it looks outdated nothing covered after this
 
 """
     $SIGNATURES

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,8 @@ include("testHasPriors913.jl")
 
 include("testInitVariableOrder.jl")
 
+include("testTreeMessageUtils.jl")
+
 include("testExpXstroke.jl")
 
 include("testBasicRecycling.jl")

--- a/test/testTreeMessageUtils.jl
+++ b/test/testTreeMessageUtils.jl
@@ -1,0 +1,40 @@
+
+using Test
+using IncrementalInference
+
+@testset "Testing tree message utils" begin
+
+N=8
+fg = generateCanonicalFG_lineStep(N; 
+                                  graphinit=false,
+                                  poseEvery=1, 
+                                  landmarkEvery=N+1, 
+                                  posePriorsAt=[0],
+                                  landmarkPriorsAt=[], 
+                                  sightDistance=N+1)
+
+deleteFactor!.(fg, [Symbol("x$(i)lm0f1") for i=1:(N-1)])
+
+# fixed eliminationOrder for repeatability
+eliminationOrder = [:x3, :x8, :x5, :x1, :x6, :lm0, :x7, :x4, :x2, :x0]
+smtasks = Task[]
+tree, smt, hists = IIF.solveTree!(fg; smtasks=smtasks, eliminationOrder=eliminationOrder)
+
+allmsgs = getTreeCliqUpMsgsAll(tree)
+#TODO better test but for now spot check a few keys
+@test issetequal(collect(2:8), keys(allmsgs)) 
+belief2 = allmsgs[2].belief
+@test issetequal([:x0, :x4], keys(belief2)) 
+
+
+stackedmsgs = stackCliqUpMsgsByVariable(tree, allmsgs)
+#everything except leave frontals
+allvars = [:lm0, :x0, :x2, :x4, :x6, :x7]
+@test issetequal(allvars, keys(stackedmsgs)) 
+@test length(stackedmsgs[:x0]) == 3
+x4stack =  stackedmsgs[:x4]
+cliq_depths = map(v->v.cliqId[]=>v.depth, x4stack)
+@test issetequal(cliq_depths, [4 => 2, 6 => 3, 2 => 1, 8 => 1])
+
+
+end


### PR DESCRIPTION
Needed for https://github.com/JuliaRobotics/RoMEPlotting.jl/pull/151
Repeating here: I changed the broken belief message `TempUpMsgPlotting` in IIF to a named tuple,  I see it as a bug fix and not a breaking change since it's been broken for a while. RoMEPlotting will need v0.21.1 compact to use `plotCliqUpMsgs` again.

Changes:
- stackCliqUpMsgsByVariable
- getTreeCliqUpMsgsAll
- UpMsgPlotting

TODO
- [x] add test 