### PR TITLE
solveCliq! in isolation

### DIFF
--- a/src/CliqueStateMachine.jl
+++ b/src/CliqueStateMachine.jl
@@ -430,10 +430,11 @@ function postUpSolve_StateMachine(csmc::CliqStateMachineContainer)
     return waitForDown_StateMachine
   end
 
+  # always put up belief message in upTx, only used for debugging isolated cliques
+  getMessageBuffer(csmc.cliq).upTx = deepcopy(beliefMsg)
   #propagate belief
   for e in getEdgesParent(csmc.tree, csmc.cliq)
     logCSM(csmc, "CSM-2e $(csmc.cliq.id): put! on edge $(e)")
-    getMessageBuffer(csmc.cliq).upTx = deepcopy(beliefMsg)
     putBeliefMessageUp!(csmc.tree, e, beliefMsg)
   end
 

--- a/src/JunctionTree.jl
+++ b/src/JunctionTree.jl
@@ -96,12 +96,14 @@ getClique(tree::MetaBayesTree, cIndex::Int) = MetaGraphs.get_prop(tree.bt, cInde
 """
     $(SIGNATURES)
 """
-function deleteClique!(tree::MetaBayesTree, cId::CliqueId)
-  clique = getClique(tree, cId) 
+function deleteClique!(tree::MetaBayesTree, clique::TreeClique)
+  cId = clique.id
   @assert MetaGraphs.rem_vertex!(tree.bt, tree.bt[:cliqId][cId]) "rem_vertex! failed"
   foreach(frt->delete!(tree.frontals,frt), getFrontals(clique))
   return clique
 end
+
+deleteClique!(tree::MetaBayesTree, cId::CliqueId) = deleteClique!(tree, getClique(tree, cId))
 
 isRoot(tree::MetaBayesTree, cliq::TreeClique) = isRoot(tree, cliq.id)
 function isRoot(tree::MetaBayesTree, cliqId::CliqueId)

--- a/src/ParametricUtils.jl
+++ b/src/ParametricUtils.jl
@@ -173,7 +173,7 @@ function solveFactorGraphParametric(fg::AbstractDFG;
                                     useCalcFactor::Bool=true, #TODO dev param will be removed
                                     solvekey::Symbol=:parametric,
                                     autodiff = :forward,
-                                    algorithm=Optim.Optim.BFGS,
+                                    algorithm=Optim.BFGS,
                                     algorithmkwargs=(), # add manifold to overwrite computed one
                                     options = Optim.Options(allow_f_increases=true,
                                                             time_limit = 100,

--- a/test/testEuclidDistance.jl
+++ b/test/testEuclidDistance.jl
@@ -98,8 +98,12 @@ tree = buildTreeReset!(fg, eo)
 
 # solveTree!(fg)
 
-@error "continue test dev with #1168"
-# stuff = solveCliq!(fg, tree, :x1)
+# @error "continue test dev with #1168"
+#solve the clique in isolation
+stuff = solveCliq!(fg, tree, :x1; recordcliq=true)
+
+# the belief that would have been sent by this clique:
+belief = IIF.getMessageBuffer(stuff[11].csmc.cliq).upTx
 
 ## still need to make sure numerical results are fine..., first must resolve #1168
 


### PR DESCRIPTION
Hi @dehann, I don't know if this is what you had in mind for `solveCliqu!` from #1168. 

I didn't know exactly what we wanted to do with solveCliq!. Problem was: It is still solving as if its part of the larger tree, so it's trying to access messages from the rest of the tree. It's easy to add the channels for the messages but then it would just block on them waiting. So where should these messages come from?

For this PR I went with solving the clique in isolation, it doesn't make sense if its not a leave clique though.