### PR TITLE
drop use of getManifolds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ The list below highlights major breaking changes, and please note that significa
 
 # Major changes in IIF v0.24
 
-- Transition to only `getManifold` (instead of `getManifolds`), thereby moving towards exclusively using Manifolds.jl, see #1141.
+- Transition to only `getManifold` (instead of `getManifolds`), thereby moving towards exclusively using Manifolds.jl, see #1234.
 # Major changes in IIF v0.23
 
 - New `@defVariable` only uses `ManifoldsBase.Manifold` as base abstraction for variable types.

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@ Alternatively, either use the Github Blame, or the Github `/compare/v0.18.0...v0
 
 The list below highlights major breaking changes, and please note that significant efforts are made to properly deprecate old code/APIs according to normal semver workflow -- i.e. breaking changes go through at least one deprecatation (via warnings) on the dominant number in the version number.  E.g. v0.18 -> v0.19 (warnings) -> v0.20 (breaking).
 
+# Major changes in IIF v0.24
+
+- Transition to only `getManifold` (instead of `getManifolds`), thereby moving towards exclusively using Manifolds.jl, see #1141.
 # Major changes in IIF v0.23
 
 - New `@defVariable` only uses `ManifoldsBase.Manifold` as base abstraction for variable types.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "IncrementalInference"
 uuid = "904591bb-b899-562f-9e6f-b8df64c7d480"
 keywords = ["MM-iSAMv2", "Bayes tree", "junction tree", "Bayes network", "variable elimination", "graphical models", "SLAM", "inference", "sum-product", "belief-propagation"]
 desc = "Implements the Multimodal-iSAMv2 algorithm."
-version = "0.23.2"
+version = "0.24.0"
 
 [deps]
 ApproxManifoldProducts = "9bbbb610-88a1-53cd-9763-118ce10c1f89"
@@ -42,11 +42,11 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-ApproxManifoldProducts = "0.3.2"
+ApproxManifoldProducts = "0.3.3"
 BSON = "0.2, 0.3"
 Combinatorics = "1.0"
 DataStructures = "0.16, 0.17, 0.18"
-DistributedFactorGraphs = "0.13.1"
+DistributedFactorGraphs = "0.14"
 Distributions = "0.20, 0.21, 0.22, 0.23, 0.24"
 DocStringExtensions = "0.8, 0.9, 0.10, 1"
 FileIO = "1.0.2, 1.1, 1.2"

--- a/src/FGOSUtils.jl
+++ b/src/FGOSUtils.jl
@@ -96,7 +96,7 @@ function manikde!(pts::AbstractArray{Float64,2},
                   bws::Vector{Float64},
                   variableType::Union{<:InstanceType{InferenceVariable}, <:InstanceType{FunctorInferenceType}}  )
   #
-  addopT, diffopT, getManiMu, getManiLam = buildHybridManifoldCallbacks(getManifolds(variableType))
+  addopT, diffopT, getManiMu, getManiLam = buildHybridManifoldCallbacks(AMP.getManifolds(variableType))
   bel = KernelDensityEstimate.kde!(pts, bws, addopT, diffopT)
   ampmani = convert(Manifold, variableType)
   return ManifoldKernelDensity(ampmani, bel)
@@ -107,7 +107,7 @@ function manikde!(pts::AbstractArray{Float64,2},
                   vartype::Union{InstanceType{<:InferenceVariable}, InstanceType{<:AbstractFactor}})
   # = manikde!(pts, getManifolds(vartype))
   #
-  addopT, diffopT, getManiMu, getManiLam = buildHybridManifoldCallbacks(getManifolds(vartype))
+  addopT, diffopT, getManiMu, getManiLam = buildHybridManifoldCallbacks(AMP.getManifolds(vartype))
   bel = KernelDensityEstimate.kde!(pts, addopT, diffopT)
   ampmani = convert(Manifold, vartype)
   return ManifoldKernelDensity(ampmani, bel)

--- a/src/FactorGraph.jl
+++ b/src/FactorGraph.jl
@@ -46,9 +46,8 @@ reshapeVec2Mat(vec::Vector, rows::Int) = reshape(vec, rows, round(Int,length(vec
 
 getManifolds(vd::VariableNodeData) = getVariableType(vd) |> getManifolds
 getManifolds(::DFGVariable{T}) where T <: InferenceVariable = getManifolds(T)
-function getManifolds(dfg::AbstractDFG, sym::Symbol)
-  return getManifolds(getVariable(dfg, sym))
-end
+getManifolds(dfg::AbstractDFG, sym::Symbol) = getManifolds(getVariable(dfg, sym))
+
 
 # getManifolds(vartype::InferenceVariable) = vartype.manifolds
 # getManifolds(vartype::Type{<: InferenceVariable}) = getManifolds(vartype())

--- a/src/Factors/EuclidDistance.jl
+++ b/src/Factors/EuclidDistance.jl
@@ -17,12 +17,12 @@ EuclidDistance(::UniformScaling=LinearAlgebra.I) = EuclidDistance(Normal())
 getDimension(::InstanceType{<:EuclidDistance}) = 1
 
 # before consolidation, see RoME.jl #244
-getManifold(::T) where{T <:EuclidDistance} = Euclidean(1)
-getManifold(::Type{T}) where{T <:EuclidDistance} = Euclidean(1)
-getManifolds(::T) where {T <:EuclidDistance} = convert(Tuple, T)
-getManifolds(::Type{<:T}) where {T <:EuclidDistance} = convert(Tuple, T)
+# getManifold(::T) where{T <:EuclidDistance} = Euclidean(1)
+# getManifold(::Type{T}) where{T <:EuclidDistance} = Euclidean(1)
+# getManifolds(::T) where {T <:EuclidDistance} = convert(Tuple, T)
+# getManifolds(::Type{<:T}) where {T <:EuclidDistance} = convert(Tuple, T)
 
-getDomain(::InstanceType{<:EuclidDistance}) = ContinuousEuclid{1}
+getManifold(::InstanceType{<:EuclidDistance}) = ContinuousEuclid{1}
 
 getSample(cf::CalcFactor{<:EuclidDistance}, N::Int=1) = (reshape(rand(cf.factor.Z,N),1,N), )
 

--- a/src/Factors/LinearRelative.jl
+++ b/src/Factors/LinearRelative.jl
@@ -28,14 +28,15 @@ LinearRelative(nm::Distributions.ContinuousUnivariateDistribution) = LinearRelat
 LinearRelative(nm::MvNormal) = LinearRelative{length(nm.μ), typeof(nm)}(nm)
 LinearRelative(nm::Union{<:BallTreeDensity,<:ManifoldKernelDensity}) = LinearRelative{Ndim(nm), typeof(nm)}(nm)
 
-getDimension(::InstanceType{LinearRelative{N}}) where {N} = N
-getManifold(::InstanceType{LinearRelative{N}}) where {N} = Euclidean(N)
-getManifolds(::T) where {T <: LinearRelative} = convert(Tuple, getManifold(T))
-getManifolds(::Type{<:T}) where {T <: LinearRelative} = convert(Tuple, getManifold(T))
-
-getDomain(::InstanceType{LinearRelative{N}}) where N = ContinuousEuclid{N}
+# getManifold(::InstanceType{LinearRelative{N}}) where {N} = Euclidean(N)
+# getManifolds(::T) where {T <: LinearRelative} = convert(Tuple, getManifold(T))
+# getManifolds(::Type{<:T}) where {T <: LinearRelative} = convert(Tuple, getManifold(T))
 # getManifolds(fctType::Type{LinearRelative}) = getManifolds(getDomain(fctType))
 
+getManifold(::InstanceType{LinearRelative{N}}) where N = ContinuousEuclid{N}
+
+# TODO standardize
+getDimension(::InstanceType{LinearRelative{N}}) where {N} = N
 
 getSample(cf::CalcFactor{<:LinearRelative}, N::Int=1) = (reshape(rand(cf.factor.Z,N),:,N), )
 

--- a/src/IncrementalInference.jl
+++ b/src/IncrementalInference.jl
@@ -60,10 +60,12 @@ import KernelDensityEstimate: getBW
 import KernelDensityEstimate: getPoints
 import ApproxManifoldProducts: kde!, manikde!
 import ApproxManifoldProducts: mmd
+import ApproxManifoldProducts: getManifolds
+# import ApproxManifoldProducts: getManifold # might be used again later
 import DistributedFactorGraphs: addVariable!, addFactor!, ls, lsf, isInitialized
 import DistributedFactorGraphs: compare, compareAllSpecial
 import DistributedFactorGraphs: rebuildFactorMetadata!
-import DistributedFactorGraphs: getDimension, getManifolds, getManifold
+import DistributedFactorGraphs: getDimension, getManifold
 
 # will be deprecated in IIF
 import DistributedFactorGraphs: isSolvable
@@ -235,7 +237,8 @@ export *,
   getVariable,
   getCliqueData,
   setCliqueData!,
-  getManifolds,
+  getManifold,  # new Manifolds.jl based operations
+  # getManifolds, # will be deprecated
   getVal,
   getBW,
   setVal!,

--- a/src/NeedsResolution.jl
+++ b/src/NeedsResolution.jl
@@ -1,4 +1,9 @@
 
+# AMP.getManifolds(::T) where {T <: InferenceVariable} = getManifolds(getManifold(T))
+# AMP.getManifolds(::Type{T}) where {T <: InferenceVariable} = getManifolds(getManifold(T))
+
+getManifolds(::InstanceType{T}) where {T <: Union{InferenceVariable, AbstractFactor}} = getManifolds(getManifold(T))
+
 
 function compare(c1::Channel,
   c2::Channel;

--- a/src/ParametricUtils.jl
+++ b/src/ParametricUtils.jl
@@ -305,15 +305,19 @@ end
 """
     MixedCircular
 Mixed Circular Manifold. Simple manifold for circular and cartesian mixed for use in optim
+
+DevNotes
+- Consolidate around `ManifoldsBase.Manifold` instead, with possible wrapper-type solution for `Optim.Manifold`
 """
 struct MixedCircular <: Optim.Manifold
   isCircular::BitArray
 end
 
+# FIXME getManifolds is being deprecated, use getManifold instead.
 function MixedCircular(fg::AbstractDFG, varIds::Vector{Symbol})
   circMask = Bool[]
   for k = varIds
-    append!(circMask, getVariableType(fg, k) |> getManifolds .== :Circular)
+    append!(circMask, getVariableType(fg, k) |> AMP.getManifolds .== :Circular)
   end
   MixedCircular(circMask)
 end

--- a/src/SubGraphFunctions.jl
+++ b/src/SubGraphFunctions.jl
@@ -131,7 +131,6 @@ function transferUpdateSubGraph!( dest::AbstractDFG,
   # transfer specific fields into dest from src
   for var in (x->getVariable(src, x)).(syms)
     # copy not required since a broadcast is used internally
-    @show solveKey
     updateVariableSolverData!(dest, var, solveKey, false, [:val; :bw; :inferdim; :solvedCount; :initialized]; warn_if_absent=false)
     if updatePPE 
       # create ppe on new key using defaults, TODO improve

--- a/src/Variables/DefaultVariables.jl
+++ b/src/Variables/DefaultVariables.jl
@@ -38,11 +38,11 @@ ContinuousEuclid(x::Int) = ContinuousEuclid{x}()
 
 getManifold(::Type{<:ContinuousEuclid{N}}) where N = Euclidean(N)
 getDimension(val::Type{<:ContinuousEuclid{N}}) where N = manifold_dimension(getManifold(val))
-getManifolds(val::Type{<:ContinuousEuclid{N}}) where N = convert(Tuple, getManifold(val))
+# getManifolds(val::Type{<:ContinuousEuclid{N}}) where N = convert(Tuple, getManifold(val))
 
 getManifold(::ContinuousEuclid{N}) where N = Euclidean(N)                               
 getDimension(val::ContinuousEuclid{N}) where N = manifold_dimension(getManifold(val))
-getManifolds(val::ContinuousEuclid{N}) where N = convert(Tuple, getManifold(val))
+# getManifolds(val::ContinuousEuclid{N}) where N = convert(Tuple, getManifold(val))
 
 Base.convert(::Type{<:ManifoldsBase.Manifold}, ::InstanceType{ContinuousEuclid{N}}) where N = Manifolds.Euclidean(N)
 

--- a/test/testBasicGraphs.jl
+++ b/test/testBasicGraphs.jl
@@ -28,8 +28,8 @@ tree, smt, hist = solveTree!(fg)
 @test isSolved(fg, :x0)
 
 # check mean and covariance
-@test (getKDE(fg, :x0) |> getKDEMean .|> abs)[1] < 0.5
-@test 0.3 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 1.9
+@test (getBelief(fg, :x0) |> getKDEMean .|> abs)[1] < 0.5
+@test 0.3 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 1.9
 
 # test free solvable variables (occurs in fixed-/ clique recycling)
 addVariable!(fg, :x1, ContinuousScalar, solvable=1)
@@ -51,8 +51,8 @@ addFactor!(fg, [:x0;], Prior(Normal(1000.0,1.0)))
 tree, smt, hist = solveTree!(fg)
 
 # check mean and covariance
-@test abs((getKDE(fg, :x0) |> getKDEMean)[1]-1000) < 0.5
-@test 0.4 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 1.8
+@test abs((getBelief(fg, :x0) |> getKDEMean)[1]-1000) < 0.5
+@test 0.4 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 1.8
 
 end
 
@@ -68,9 +68,9 @@ addFactor!(fg, [:x0;], Prior(Normal(0.0,1.0)))
 tree, smt, hist = solveTree!(fg)
 
 # check mean and covariance
-@test (getKDE(fg, :x0) |> getKDEMean .|> abs)[1] < 0.4
+@test (getBelief(fg, :x0) |> getKDEMean .|> abs)[1] < 0.4
 # should be sqrt(0.5) = 0.7, but lands near 0.6 instead -- computation is too confident.
-@test 0.3 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 1.0
+@test 0.3 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 1.0
 
 end
 
@@ -87,9 +87,9 @@ addFactor!(fg, [:x0;], Prior(Normal(0.0,1.0)))
 tree, smt, hist = solveTree!(fg)
 
 # check mean and covariance
-@test (getKDE(fg, :x0) |> getKDEMean .|> abs)[1] < 0.4
+@test (getBelief(fg, :x0) |> getKDEMean .|> abs)[1] < 0.4
 # should be sqrt(1/3) = 0.577, but lands near 0.35 instead -- computation is too confident.
-@test 0.1 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 0.75
+@test 0.1 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 0.75
 
 end
 
@@ -106,9 +106,9 @@ addFactor!(fg, [:x0;], Prior(Normal(+1.0,1.0)))
 tree, smt, hist = solveTree!(fg)
 
 # check mean and covariance -- should be zero
-@test (getKDE(fg, :x0) |> getKDEMean .|> abs)[1] < 0.8
+@test (getBelief(fg, :x0) |> getKDEMean .|> abs)[1] < 0.8
 # should be sqrt(1/2) = 0.707 -- computation results nearer 0.7.
-@test 0.2 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 1.5
+@test 0.2 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 1.5
 
 end
 
@@ -124,9 +124,9 @@ addFactor!(fg, [:x0;], Prior(Normal(+1.0-1000,1.0)))
 tree, smt, hist = solveTree!(fg)
 
 # check mean and covariance -- should be zero
-@test abs((getKDE(fg, :x0) |> getKDEMean)[1] + 1000) < 0.6
+@test abs((getBelief(fg, :x0) |> getKDEMean)[1] + 1000) < 0.6
 # should be sqrt(1/2) = 0.707 -- computation results nearer 0.7.
-@test 0.2 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 1.1
+@test 0.2 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 1.1
 
 end
 
@@ -145,11 +145,11 @@ addFactor!(fg, [:x0;:x1;], LinearRelative(Normal(0.0,10.0)))
 tree, smt, hist = solveTree!(fg)
 
 # check mean and covariance -- should be zero
-@test (getKDE(fg, :x0) |> getKDEMean .|> abs)[1] < 0.6
-@test (getKDE(fg, :x1) |> getKDEMean .|> abs)[1] < 0.6
+@test (getBelief(fg, :x0) |> getKDEMean .|> abs)[1] < 0.6
+@test (getBelief(fg, :x1) |> getKDEMean .|> abs)[1] < 0.6
 
-@test 0.4 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 2.2
-@test 0.4 < Statistics.cov( getPoints(getKDE(fg, :x1))[1,:] ) < 2.3
+@test 0.4 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 2.3
+@test 0.4 < Statistics.cov( getPoints(getBelief(fg, :x1))[1,:] ) < 2.4
 
 end
 
@@ -167,11 +167,11 @@ addFactor!(fg, [:x0;:x1;], LinearRelative(Normal(0.0,10.0)))
 tree, smt, hist = solveTree!(fg)
 
 # check mean and covariance -- should be near each prior
-@test abs((getKDE(fg, :x0) |> getKDEMean)[1]+1) < 0.75
-@test abs((getKDE(fg, :x1) |> getKDEMean)[1]-1) < 0.75
+@test abs((getBelief(fg, :x0) |> getKDEMean)[1]+1) < 0.75
+@test abs((getBelief(fg, :x1) |> getKDEMean)[1]-1) < 0.75
 
-@test 0.3 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 2.5
-@test 0.3 < Statistics.cov( getPoints(getKDE(fg, :x1))[1,:] ) < 2.5
+@test 0.3 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 2.5
+@test 0.3 < Statistics.cov( getPoints(getBelief(fg, :x1))[1,:] ) < 2.5
 
 end
 
@@ -193,13 +193,13 @@ tree, smt, hist = solveTree!(fg)
 
 
 # check mean and covariance -- should between two priors somewhere
-@test abs((getKDE(fg, :x0) |> getKDEMean)[1] + 1) < 0.9
-@test abs((getKDE(fg, :x1) |> getKDEMean)[1]) < 0.9
-@test abs((getKDE(fg, :x2) |> getKDEMean)[1] - 1) < 0.9
+@test abs((getBelief(fg, :x0) |> getKDEMean)[1] + 1) < 0.9
+@test abs((getBelief(fg, :x1) |> getKDEMean)[1]) < 0.9
+@test abs((getBelief(fg, :x2) |> getKDEMean)[1] - 1) < 0.9
 
-@test 0.3 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 1.8
-@test 0.3 < Statistics.cov( getPoints(getKDE(fg, :x1))[1,:] ) < 2.0
-@test 0.3 < Statistics.cov( getPoints(getKDE(fg, :x2))[1,:] ) < 2.2
+@test 0.3 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 1.8
+@test 0.3 < Statistics.cov( getPoints(getBelief(fg, :x1))[1,:] ) < 2.0
+@test 0.3 < Statistics.cov( getPoints(getBelief(fg, :x2))[1,:] ) < 2.2
 
 end
 
@@ -227,16 +227,16 @@ drawGraph(fg, filepath="testgraphplot/myfg.dot", show=false)
 tree, smt, hist = solveTree!(fg, storeOld=true)
 
 # using KernelDensityEstimatePlotting
-# plotKDE((x->getKDE(fg,x)).([:x0;:x1;:x2;:x3;:x4]))
+# plotKDE((x->getBelief(fg,x)).([:x0;:x1;:x2;:x3;:x4]))
 # using Gadfly, Cairo, Fontconfig
 # drawTree(tree,show=true,imgs=true)
 
 # check mean and covariance -- should be zero
-X0 = (getKDE(fg, :x0) |> getKDEMean)[1]
-X1 = (getKDE(fg, :x1) |> getKDEMean)[1]
-X2 = (getKDE(fg, :x2) |> getKDEMean)[1]
-X3 = (getKDE(fg, :x3) |> getKDEMean)[1]
-X4 = (getKDE(fg, :x4) |> getKDEMean)[1]
+X0 = (getBelief(fg, :x0) |> getKDEMean)[1]
+X1 = (getBelief(fg, :x1) |> getKDEMean)[1]
+X2 = (getBelief(fg, :x2) |> getKDEMean)[1]
+X3 = (getBelief(fg, :x3) |> getKDEMean)[1]
+X4 = (getBelief(fg, :x4) |> getKDEMean)[1]
 
 @test X0 < X1 < X2 < X3 < X4
 
@@ -244,11 +244,11 @@ X4 = (getKDE(fg, :x4) |> getKDEMean)[1]
 @test abs(X1+X3) < 2.2
 @test abs(X2) < 2.2
 
-@test 0.2 < Statistics.cov( getPoints(getKDE(fg, :x0))[1,:] ) < 2.3
-@test 0.2 < Statistics.cov( getPoints(getKDE(fg, :x1))[1,:] ) < 2.4
-@test 0.2 < Statistics.cov( getPoints(getKDE(fg, :x2))[1,:] ) < 2.6
-@test 0.2 < Statistics.cov( getPoints(getKDE(fg, :x3))[1,:] ) < 2.7
-@test 0.2 < Statistics.cov( getPoints(getKDE(fg, :x4))[1,:] ) < 2.8
+@test 0.2 < Statistics.cov( getPoints(getBelief(fg, :x0))[1,:] ) < 2.3
+@test 0.2 < Statistics.cov( getPoints(getBelief(fg, :x1))[1,:] ) < 2.4
+@test 0.2 < Statistics.cov( getPoints(getBelief(fg, :x2))[1,:] ) < 2.6
+@test 0.2 < Statistics.cov( getPoints(getBelief(fg, :x3))[1,:] ) < 2.7
+@test 0.2 < Statistics.cov( getPoints(getBelief(fg, :x4))[1,:] ) < 2.8
 
 @testset "Test localProduct on solveKey" begin
 
@@ -273,18 +273,18 @@ addFactor!(fg, [:x0;], Prior(Normal(1000.0,1.0)))
 ensureAllInitialized!(fg)
 
 # init values before solve
-X0 = getPoints( getKDE(fg, :x0)) |> deepcopy
+X0 = getPoints( getBelief(fg, :x0)) |> deepcopy
 
 tree, smt, hist = solveTree!(fg)
 
 # values after solve
-X0s = getPoints( getKDE(fg, :x0))
+X0s = getPoints( getBelief(fg, :x0))
 
 @test 1e-10 < norm(X0 - X0s)
 
 resetInitialValues!(fg)
 
-X0reset = getPoints( getKDE(fg, :x0)) |> deepcopy
+X0reset = getPoints( getBelief(fg, :x0)) |> deepcopy
 
 @test norm(X0 - X0reset) < 1e-10
 

--- a/test/testBasicParametric.jl
+++ b/test/testBasicParametric.jl
@@ -7,13 +7,13 @@ using IncrementalInference
 @testset "Test consolidation of factors #467" begin
   fg = generateCanonicalFG_lineStep(20, poseEvery=1, landmarkEvery=4, posePriorsAt=collect(0:7), sightDistance=2, solverParams=SolverParams(algorithms=[:default, :parametric]))
 
-  d,st = IIF.solveFactorGraphParametric(fg)
+  d,st = IIF.solveGraphParametric(fg)
   for i in 0:10
     sym = Symbol("x",i)
     @test isapprox(d[sym].val[1], i, atol=1e-6)
   end
   
-  d,st = IIF.solveFactorGraphParametric(fg; useCalcFactor=true)
+  d,st = IIF.solveGraphParametric(fg; useCalcFactor=true)
   for i in 0:10
     sym = Symbol("x",i)
     @test isapprox(d[sym].val[1], i, atol=1e-6)
@@ -27,7 +27,7 @@ end
 ##
 fg = generateCanonicalFG_lineStep(7, poseEvery=1, landmarkEvery=0, posePriorsAt=collect(0:7), sightDistance=2, solverParams=SolverParams(algorithms=[:default, :parametric]))
 
-d, result = IIF.solveFactorGraphParametric(fg)
+d, result = IIF.solveGraphParametric(fg)
 
 for i in 0:7
   sym = Symbol("x",i)
@@ -54,8 +54,8 @@ fg = generateCanonicalFG_lineStep(10, vardims=2, poseEvery=1, landmarkEvery=3, p
 #to manually check all factors
 # foreach(fct->println(fct.label, ": ", getFactorType(fct).Z), getFactors(fg))
 
-# @profiler d,st = IIF.solveFactorGraphParametric(fg)
-d,st = IIF.solveFactorGraphParametric(fg)
+# @profiler d,st = IIF.solveGraphParametric(fg)
+d,st = IIF.solveGraphParametric(fg)
 
 for i in 0:10
   sym = Symbol("x",i)
@@ -120,7 +120,7 @@ addFactor!(fg, [:x1; :x2], LinearRelative(Normal(0.0, 1e-1)), graphinit=graphini
 
 foreach(fct->println(fct.label, ": ", getFactorType(fct).Z), getFactors(fg))
 
-d,st,vs,Σ = IIF.solveFactorGraphParametric(fg)
+d,st,vs,Σ = IIF.solveGraphParametric(fg)
 
 foreach(println, d)
 @test isapprox(d[:x0].val[1], -0.01, atol=1e-4)
@@ -160,8 +160,8 @@ deleteFactor!(fg, :x5x6f1)
 #check all factors
 # foreach(fct->println(fct.label, ": ", getFactorType(fct).Z), getFactors(fg))
 
-# @profiler d,st = IIF.solveFactorGraphParametric(fg)
-d,st = IIF.solveFactorGraphParametric(fg)
+# @profiler d,st = IIF.solveGraphParametric(fg)
+d,st = IIF.solveGraphParametric(fg)
 
 if false
 foreach(println, d)

--- a/test/testDeadReckoningTether.jl
+++ b/test/testDeadReckoningTether.jl
@@ -21,7 +21,7 @@ MutableLinearConditional(nm::MvNormal) = MutableLinearConditional{length(nm.μ),
 MutableLinearConditional(nm::BallTreeDensity) = MutableLinearConditional{Ndim(nm), typeof(nm)}(nm)
 
 getDimension(::Type{MutableLinearConditional{N,<:SamplableBelief}}) where {N} = N
-getManifolds(::Type{MutableLinearConditional{N,<:SamplableBelief}}) where {N} = tuple([:Euclid for i in 1:N]...)
+# getManifolds(::Type{MutableLinearConditional{N,<:SamplableBelief}}) where {N} = tuple([:Euclid for i in 1:N]...)
 
 IIF.getSample(cf::CalcFactor{<:MutableLinearConditional}, N::Int=1) = (reshape(rand(cf.factor.Z,N),:,N), )
 function (s::CalcFactor{<:MutableLinearConditional})(meas,


### PR DESCRIPTION
Only use `getManifold` instead.  Also completely dropping `getDomain`.

relates to 
- #1010,
- #1141,
- JuliaRobotics/RoME.jl#244