### PR TITLE
improve API, towards infoPerCoord

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ The list below highlights major breaking changes, and please note that significa
 
 # Major changes in v0.25
 
+- Changed API to `testFactorResidualBinary(fct, meas::Tuple, (T_i, param_i),...)` to grow beyond binary.
 - PPE methods used keyword `method::AbstractPointParametricType` which is now replaced with the keyword `ppeType`.
 - Belief points are now stored as a `Vector{P}` (rather than legacy `Matrix`), and currently still under the restriction `P <: AbstractVector{<:Real}`.  Objective is moving to `P` any user desired point that fits with the JuliaManifolds/Manifolds.jl patterns.
 - Deprecating use of `ensureAllInitialized!`, use `initAll!` instead.

--- a/Project.toml
+++ b/Project.toml
@@ -43,7 +43,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-ApproxManifoldProducts = "0.4.3"
+ApproxManifoldProducts = "0.4.5"
 BSON = "0.2, 0.3"
 Combinatorics = "1.0"
 DataStructures = "0.16, 0.17, 0.18"

--- a/examples/dev/factor_gradients.jl
+++ b/examples/dev/factor_gradients.jl
@@ -1,0 +1,60 @@
+
+# PoC on jacobians for a factor
+
+using IncrementalInference
+
+##
+
+pp = LinearRelative(MvNormal([10;0],[1 0; 0 1]))
+
+
+##
+
+
+testFactorResidualBinary(pp, ([1;0],), (ContinuousEuclid{2}, [0;0]), (ContinuousEuclid{2},[0;0]) )
+
+
+# T_pt_args[:] = [(T1::Type{<:InferenceVariable}, point1); ...]
+function _calcGradientFactorBinary( fct::Union{<:AbstractRelativeMinimize,<:AbstractRelativeRoots}, 
+                                    meas::Tuple,
+                                    T_pt_args...;
+                                    h::Real=1e-8 ) # numerical diff perturbation size
+  #
+  # gradients relative to coords requires 
+  resid_ = testFactorResidualBinary(fct, meas, T_pt_args...)
+  
+  # build a residual calculation specifically considering graph factor selections `s`, e.g. for binary `s ∈ {1,2}``.
+  δ_s = (s,T_pt) -> testFactorResidualBinary(fct, meas, (T_pt_args[1:(s-1)])..., T_pt, (T_pt_args[(s+1):end])...)
+  # TODO generalize beyond binary
+
+  # each variable T, go down to coords, add eps to a coord, back to point and look at the change in residual (assumed in coords for AbstractRelative[Minimize/Roots])
+  for (a_, Tpt_) in enumerate(T_pt_args)
+    # assume binary factor to start, these are variables A and B
+    Ta = Tpt_[1]
+    Ma = getManifold(Ta)
+    pt_a = Tpt_[2]
+    u_a = pt_a
+      
+    # replace with retract operations only
+    coords_a = AMP.makeCoordsFromPoint(Ma, pt_a)
+    # perturb coords
+    pr_coord_ = (i) -> (ca_ = deepcopy(coords_a); ca_[i] += h; ca_)  
+    pt_a_i = (i) -> AMP.makePointFromCoords(Ma,pr_coord_(i),u_a)
+    resid_a_i = (s,i) -> δ_s(s, (Ta, pt_a_i(i)))
+    # standard calculus derivative definition (in coordinate space)
+    Δf_h = (i) -> (resid_a_i(a_,i) - resid_)./h
+    # jacobian block in reverse indices
+    ▽f = () -> ((i->Δf_h(i)).(1:length(coords_a)))
+    # jacobian stored in user provided matrix
+    ▽f_ij! = (J) -> (J_ = ▽f(); (@cast J[i,j] = J_[j][i]))
+
+    # function is ready but calculation must still be done
+  end
+  
+
+
+end
+
+
+
+#

--- a/examples/dev/factor_gradients.jl
+++ b/examples/dev/factor_gradients.jl
@@ -46,7 +46,7 @@ function _calcGradientFactorBinary( fct::Union{<:AbstractRelativeMinimize,<:Abst
     # jacobian block in reverse indices
     ▽f = () -> ((i->Δf_h(i)).(1:length(coords_a)))
     # jacobian stored in user provided matrix
-    ▽f_ij! = (J) -> (J_ = ▽f(); (@cast J[i,j] = J_[j][i]))
+    ▽f_ij! = (J::AbstractMatrix{<:Real}) -> (J_ = ▽f(); (@cast J[i,j] = J_[j][i]))
 
     # function is ready but calculation must still be done
   end

--- a/src/ApproxConv.jl
+++ b/src/ApproxConv.jl
@@ -832,49 +832,39 @@ The remaining dimensions will keep pre-existing variable values.
 Notes
 - fulldim is true when "rank-deficient" -- TODO swap to false (or even float)
 """
-function findRelatedFromPotential(dfg::AbstractDFG,
-                                  fct::DFGFactor,
-                                  target::Symbol,
-                                  measurement::Tuple=(Vector{Vector{Float64}}(),);
-                                  N::Int=length(measurement[1]),
-                                  solveKey::Symbol=:default,
-                                  dbg::Bool=false  )
+function calcProposalBelief(dfg::AbstractDFG,
+                            fct::DFGFactor,
+                            target::Symbol,
+                            measurement::Tuple=(Vector{Vector{Float64}}(),);
+                            N::Int=length(measurement[1]),
+                            solveKey::Symbol=:default,
+                            dbg::Bool=false  )
   #
-  # need way to convey partial information
-  # determine if evaluation is "dimension-deficient"
-  # solvable dimension
-  inferdim = getFactorSolvableDim(dfg, fct, target, solveKey)
-  
-  # # # assuming it is properly initialized TODO
+  # assuming it is properly initialized TODO
   proposal = approxConvBelief(dfg, fct, target, measurement, solveKey=solveKey, N=N)
 
   # return the proposal belief and inferdim, NOTE likely to be changed
-  return (proposal, inferdim)
+  return proposal
 end
 
 
-function findRelatedFromPotential(dfg::AbstractDFG,
-                                  fct::DFGFactor{<:CommonConvWrapper{<:PartialPriorPassThrough}},
-                                  target::Symbol,
-                                  measurement::Tuple=(zeros(0,0),);
-                                  N::Int=length(measurement[1]),
-                                  solveKey::Symbol=:default,
-                                  dbg::Bool=false  )
+function calcProposalBelief(dfg::AbstractDFG,
+                            fct::DFGFactor{<:CommonConvWrapper{<:PartialPriorPassThrough}},
+                            target::Symbol,
+                            measurement::Tuple=(zeros(0,0),);
+                            N::Int=length(measurement[1]),
+                            solveKey::Symbol=:default,
+                            dbg::Bool=false  )
   #
-  # determine if evaluation is "dimension-deficient"
-  # solvable dimension
-  inferdim = getFactorSolvableDim(dfg, fct, target, solveKey)
 
   # density passed through directly from PartialPriorPassThrough.Z
   proposal = getFactorType(fct).Z.densityFnc
 
-  return (proposal, inferdim)
+  # return the proposal belief and inferdim, NOTE likely to be changed
+  return proposal
 end
 
-# function _expandNamedTupleType()
-  
-# end
-
+@deprecate findRelatedFromPotential(w...;kw...) (calcProposalBelief(w...;kw...),)
 
 """
     $SIGNATURES
@@ -886,26 +876,27 @@ Notes
 - TODO: also return if proposals were "dimension-deficient" (aka ~rank-deficient).
 """
 function proposalbeliefs!(dfg::AbstractDFG,
-                          destvertlabel::Symbol,
+                          destlbl::Symbol,
                           factors::AbstractVector{<:DFGFactor},
                           dens::Vector{<:ManifoldKernelDensity},
                           # partials::Dict{Any, Vector{ManifoldKernelDensity}}, # TODO change this structure
                           measurement::Tuple=(Vector{Vector{Float64}}(),);
                           solveKey::Symbol=:default,
-                          N::Int=maximum([length(getPoints(getBelief(dfg, destvertlabel, solveKey))); getSolverParams(dfg).N]),
+                          N::Int=maximum([length(getPoints(getBelief(dfg, destlbl, solveKey))); getSolverParams(dfg).N]),
                           dbg::Bool=false  )
   #
-  
-
-  # group partial dimension factors by selected dimensions -- i.e. [(1,)], [(1,2),(1,2)], [(2,);(2;)]
-
 
   # populate the full and partial dim containers
   inferddimproposal = Vector{Float64}(undef, length(factors))
+  # get a proposal belief from each factor connected to destlbl
   for (count,fct) in enumerate(factors)
     data = getSolverData(fct)
     ccwl = _getCCW(data)
-    propBel_, inferd = findRelatedFromPotential(dfg, fct, destvertlabel, measurement, N=N, dbg=dbg, solveKey=solveKey)
+    # need way to convey partial information
+    # determine if evaluation is "dimension-deficient" solvable dimension
+    inferd = getFactorSolvableDim(dfg, fct, destlbl, solveKey)
+    # convolve or passthrough to get a new proposal
+    propBel_ = calcProposalBelief(dfg, fct, destlbl, measurement, N=N, dbg=dbg, solveKey=solveKey)
     # partial density
     propBel = if isPartial(ccwl)
       pardims = _getDimensionsPartial(ccwl)
@@ -919,6 +910,8 @@ function proposalbeliefs!(dfg::AbstractDFG,
   end
   inferddimproposal
 end
+# group partial dimension factors by selected dimensions -- i.e. [(1,)], [(1,2),(1,2)], [(2,);(2;)]
+
 
 
 

--- a/src/ApproxConv.jl
+++ b/src/ApproxConv.jl
@@ -890,8 +890,8 @@ function proposalbeliefs!(dfg::AbstractDFG,
   inferddimproposal = Vector{Float64}(undef, length(factors))
   # get a proposal belief from each factor connected to destlbl
   for (count,fct) in enumerate(factors)
-    data = getSolverData(fct)
-    ccwl = _getCCW(data)
+    # data = getSolverData(fct)
+    ccwl = _getCCW(fct)
     # need way to convey partial information
     # determine if evaluation is "dimension-deficient" solvable dimension
     inferd = getFactorSolvableDim(dfg, fct, destlbl, solveKey)

--- a/src/CalcFactor.jl
+++ b/src/CalcFactor.jl
@@ -72,21 +72,30 @@ Evaluate the residual function for a single sample.
 
 Notes
 - Binary factors only at this stage, and `multihypo` does not have to be considered in this test
+- Assumes calculation is for a single particle, so `meas::Tuple{Z,other}` is only a single particles value.
 
 DevNotes
 - TODO generalize for n-ary factors
+
+Example
+```julia
+residual = testFactorResidualBinary(Pose2Pose2(...), (z_i,), (RoME.Pose2, x1), (RoME.Pose2, x2))
+```
 
 Related
 
 [`approxConv`](@ref), [`CalcResidual`](@ref)
 """
-function testFactorResidualBinary(fct, 
-                                  T1,
-                                  T2,
-                                  param1,
-                                  param2, 
-                                  meas::Tuple = ())
+function testFactorResidualBinary(fct::AbstractRelative, 
+                                  meas::Tuple,
+                                  T_param_args... )
   #
+
+  # TODO generalize beyond binary
+  T1 = T_param_args[1][1]
+  param1 = T_param_args[1][2]
+  T2 = T_param_args[2][1]
+  param2 = T_param_args[2][2]
 
   fg_ = initfg()
   X0 = addVariable!(fg_, :x0, T1)
@@ -112,6 +121,8 @@ function testFactorResidualBinary(fct,
 
   return res
 end
+
+
 
 
 #

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -25,6 +25,8 @@ end
 ## Deprecate code below before v0.27
 ##==============================================================================
 
+@deprecate testFactorResidualBinary(fct, T1,T2, param1, param2, meas::Tuple) testFactorResidualBinary(fct, meas, (T1,param1), (T2,param2))
+
 # """
 #     $SIGNATURES
 #

--- a/src/FGOSUtils.jl
+++ b/src/FGOSUtils.jl
@@ -144,14 +144,16 @@ function manikde!(pts::AbstractVector{P},
                   variableType::Union{InstanceType{<:InferenceVariable}, InstanceType{<:AbstractFactor}}  ) where P
   #
   M = getManifold(variableType)
-  return AMP.manikde!(M, pts, bws)
+  infoPerCoord=ones(AMP.getNumberCoords(M, pts[1]))
+  return AMP.manikde!(M, pts, bw=bws, infoPerCoord=infoPerCoord)
 end
 
 function manikde!(pts::AbstractVector{P}, 
                   vartype::Union{InstanceType{<:InferenceVariable}, InstanceType{<:AbstractFactor}}) where P
   #
   M = getManifold(vartype)
-  return AMP.manikde!(M, pts)
+  @show infoPerCoord=ones(AMP.getNumberCoords(M, pts[1]))
+  return AMP.manikde!(M, pts, infoPerCoord=infoPerCoord)
 end
 
 

--- a/test/testSpecialOrthogonalMani.jl
+++ b/test/testSpecialOrthogonalMani.jl
@@ -4,7 +4,11 @@ using Manifolds
 using StaticArrays
 using Test
 
+##
+
 @testset "Test SpecialOrthogonal(2) prior" begin
+
+##
 
 Base.convert(::Type{<:Tuple}, M::SpecialOrthogonal{2}) = (:Circular,)
 Base.convert(::Type{<:Tuple}, ::IIF.InstanceType{SpecialOrthogonal{2}})  = (:Circular,)
@@ -29,6 +33,8 @@ v0 = addVariable!(fg, :x0, SpecialOrthogonal2)
 mp = ManifoldPrior(SpecialOrthogonal(2), SA[1.0 0.0; 0.0 1.0], MvNormal([0.01]))
 p = addFactor!(fg, [:x0], mp)
 
+##
+
 doautoinit!(fg, :x0)
 
 vnd = getVariableSolverData(fg, :x0)
@@ -44,9 +50,11 @@ f = addFactor!(fg, [:x0, :x1], mf)
 doautoinit!(fg, :x1)
 
 ##
-smtasks = Task[]
-solveTree!(fg; smtasks, verbose=true, recordcliqs=ls(fg))
+# smtasks = Task[]
+solveTree!(fg) #; smtasks, verbose=true, recordcliqs=ls(fg))
 # hists = fetchCliqHistoryAll!(smtasks);
+
+##
 
 end
 
@@ -96,8 +104,8 @@ vnd = getVariableSolverData(fg, :x1)
 @test all(isapprox.( mean(SpecialOrthogonal(3),vnd.val), [0.9999 -0.00995 0.01005; 0.01005 0.9999 -0.00995; -0.00995 0.01005 0.9999], atol=0.01))
 @test all(is_point.(Ref(M), vnd.val))
 
-smtasks = Task[]
-solveTree!(fg; smtasks, verbose=true, recordcliqs=ls(fg))
+# smtasks = Task[]
+solveTree!(fg) # ; smtasks, verbose=true, recordcliqs=ls(fg))
 
 # test them again after solve
 vnd = getVariableSolverData(fg, :x0)


### PR DESCRIPTION
HI @Affie , see the start of a crude-memory jacobian calculator for factor residuals (in coordinates).  I was thinking of making this a functor to improve in-place operations, but that would be a later optimization. What I'd like to do here is via many lambdas create a constructor for say `struct FactorJacobian` which generates all the necessary numerical lambdas during construction, but can then calculate more quickly calculate the gradients when needed.  For example, something to the effect of:
```julia
# just the factor (no factor graph should be needed)
pp = Pose2Pose2(...)

# describe the jacobian for a factor connected to two variables
jacobian_functor = IIF.FactorJacobian(pp, Pose2, Pose2)

# but now the jacobian is only computed when you ask for it
_J = zeros(6,6)
jacobian_functor(J_, z, p1, p2) # doing inplace operations on `J_` based on current values in `z,p1,p2`

# and look at the jacobian given values for p1, p2.
@show _J

# and recalc new jacobian at different values 
jacobian_functor(J_, z, p3, p4)
```

This is still the jacobian relative to residual coordinates, so a bit more is needed to construct the gradients for the cost function, but that should hopefully be quite easy using the inner product and derivative chain rule.