### PR TITLE
Adding getFactorOperationalMemoryType for NoSolverParams

### DIFF
--- a/src/IncrementalInference.jl
+++ b/src/IncrementalInference.jl
@@ -410,7 +410,7 @@ const InMemDFGType = DFG.LightDFG{SolverParams}
 import DistributedFactorGraphs: getFactorOperationalMemoryType
 
 getFactorOperationalMemoryType(dfg::SolverParams) = CommonConvWrapper
-
+getFactorOperationalMemoryType(dfg::NoSolverParams) = CommonConvWrapper
 
 include("AliasScalarSampling.jl")
 include("entities/OptionalDensities.jl")


### PR DESCRIPTION
This is needed to support getFactor() for DFG types that use NoSolverParams.