### PR TITLE
differential factors from deconv tangents to points

### DIFF
--- a/src/DeconvUtils.jl
+++ b/src/DeconvUtils.jl
@@ -11,12 +11,11 @@ export approxDeconv, deconvSolveKey
 """
     $SIGNATURES
 
-Inverse solve of predicted noise value and returns tuple of (newly predicted, and known "measured" 
-noise) values.
+Inverse solve of predicted noise value and returns tuple of (newly calculated-predicted, and known measurements) values.
 
 Notes
 - Only works for first value in measurement::Tuple at this stage.
-- "measured" is used as starting point for the "predicted" values solve.
+- "measured" is used as starting point for the "calculated-predicted" values solve.
 - Not all factor evaluation cases are support yet.
 - NOTE only works on `.threadid()==1` at present, see #1094
 - This function is still part of the initial implementation and needs a lot of generalization improvements.

--- a/src/IncrementalInference.jl
+++ b/src/IncrementalInference.jl
@@ -15,6 +15,7 @@ using Reexport
 using Manifolds
 
 export ℝ, AbstractManifold
+export ProductRepr
 # common groups -- preferred defaults at this time.
 export TranslationGroup, CircleGroup
 # common non-groups -- TODO still teething problems to sort out in IIF v0.25-v0.26.

--- a/src/TreeMessageUtils.jl
+++ b/src/TreeMessageUtils.jl
@@ -11,7 +11,7 @@ export addLikelihoodsDifferentialCHILD!
 
 
 
-convert(::Type{<:ManifoldKernelDensity}, src::TreeBelief) = manikde!(src.val, src.bw[:,1], getManifold(src.variableType))
+convert(::Type{<:ManifoldKernelDensity}, src::TreeBelief) = manikde!(getManifold(src.variableType), src.val, bw=src.bw[:,1])
 
 """
     $(SIGNATURES)
@@ -311,8 +311,10 @@ function addLikelihoodsDifferentialCHILD!(cliqSubFG::AbstractDFG,
           # assume default helper function # buildFactorDefault(nfactype)
           afc = addFactor!(tfg, [sym1_;sym2_], sft, graphinit=false, tags=[:DUMMY;])
           # calculate the general deconvolution between variables
-          pts, = approxDeconv(tfg, afc.label, solveKey)  # solveFactorMeasurements
-          # @show sft
+          pred_X, = approxDeconv(tfg, afc.label, solveKey)  # solveFactorMeasurements
+          M = getManifold(_sft)
+          e0 = identity_element(M)
+          pts = exp.(Ref(M), Ref(e0), pred_X)
           newBel = manikde!(pts, sft)
           # replace dummy factor with real deconv factor using manikde approx belief measurement
           fullFct = _sft(newBel)


### PR DESCRIPTION
a change that came as part of Manifolds.jl upgrade.  This PR restricts to only Lie group manifolds, but advances differential factors to use new approxDeconv which now returns tangents (previously was always assumed just to be tangents).  Relaxing the Lie group assumption should happen along with #1010 

Closes #1386 