### PR TITLE
workaround for partials, xref #1492

### DIFF
--- a/src/services/EvalFactor.jl
+++ b/src/services/EvalFactor.jl
@@ -456,7 +456,9 @@ function evalPotentialSpecific( Xi::AbstractVector{<:DFGVariable},
         #FIXME check if getManifold is defined otherwise fall back to getManifoldPartial, JT: I would like to standardize to getManifold
         if hasmethod(getManifold, (typeof(fnc),))
           Msrc = getManifold(fnc)
-          setPointPartial!(mani, addEntr[m], Msrc, ccwl.measurement[m], partialCoords, false)
+          # TODO workaround until partial manifold approach is standardized, see #1492
+          asPartial = isPartial(fnc) && manifold_dimension(Msrc) < manifold_dimension(mani)
+          setPointPartial!(mani, addEntr[m], Msrc, ccwl.measurement[m], partialCoords, asPartial)
         else
           Msrc, = getManifoldPartial(mani, partialCoords)
           setPointPartial!(mani, addEntr[m], Msrc, ccwl.measurement[m], partialCoords)


### PR DESCRIPTION
this is a workaround, deferring proper fix as part of #1492 

This workaround keeps fuzzy whether partial factor manifolds should be full dimension from one of the associated variables, or restricted to only the dimensions in question.  E.g. what manifold should this return: `getManifold(Pose2Point2BearingRange)` -- `SE(2)`, `Translation(2)`?