### PR TITLE
Refactor CI tests for known stochastic issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - release**
   workflow_dispatch:
 jobs:
-    test-stable:
+  test-stable:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
     env:
@@ -47,19 +47,17 @@ jobs:
         if: ${{ matrix.version != 'nightly' }}
 
   test-debug-group:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.group }}
+    name: Julia ${{ version }} - ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
+    arch: 'x64'
+    version: '1.8'
     env:
       JULIA_PKG_SERVER: ""
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.8'
         os:
           - ubuntu-latest
-        arch:
-          - x64
         group:
           - 'tmp_debug_group'
     steps:
@@ -82,10 +80,10 @@ jobs:
         if: ${{ matrix.version != 'nightly' }}
 
   upstream-dev:
-    #if: github.ref != 'refs/heads/release**'
     needs: [ test-debug-group ]
     name: Upstream Dev
     runs-on: ubuntu-latest
+    arch: x64
     env: 
       JULIA_PKG_SERVER: ""
     strategy:
@@ -94,10 +92,6 @@ jobs:
         version:
           - '1.8'
           - 'nightly'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
         group:
           - 'basic_functional_group'
           - 'test_cases_group'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           - x64
         group:
           - 'tmp_debug_group'
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -110,6 +111,8 @@ jobs:
           git config --global user.name Tester
           git config --global user.email te@st.er
       - name: Upstream Dev
+        env:
+          IIF_TEST_GROUP: ${{ matrix.group }}
         run: |
           julia --project=@. --check-bounds=yes -e 'using Pkg; Pkg.add(PackageSpec(name="ApproxManifoldProducts",rev="master"));'
           julia --project=@. --check-bounds=yes -e 'using Pkg; Pkg.add(PackageSpec(name="DistributedFactorGraphs",rev="master"));' 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,8 @@ jobs:
         if: ${{ matrix.version != 'nightly' }}
 
   test-debug-group:
-    name: Julia 1.8 - ${{ matrix.group }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
-    arch: x64
-    version: 1.8
     env:
       JULIA_PKG_SERVER: ""
     strategy:
@@ -58,11 +56,18 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+        version:
+          - '1.8'
+        arch:
+          - x64
         group:
           - 'tmp_debug_group'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,6 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           IIF_TEST_GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
-        with:
-          files: lcov.info
-          fail_ci_if_error: false
-        if: ${{ matrix.version != 'nightly' }}
 
   upstream-dev:
     needs: [ test-debug-group ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   test-stable:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.group }}
+    name: JL${{ matrix.version }} - ${{ matrix.arch }} - ${{ matrix.group }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
       JULIA_PKG_SERVER: ""
@@ -47,7 +47,7 @@ jobs:
         if: ${{ matrix.version != 'nightly' }}
 
   test-debug-group:
-    name: Julia ${{ matrix.version }} - ${{ matrix.group }}
+    name: JL${{ matrix.version }} - ${{ matrix.group }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
       JULIA_PKG_SERVER: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - release**
   workflow_dispatch:
 jobs:
-  test-stable:
+    test-stable:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
     env:
@@ -27,6 +27,40 @@ jobs:
         group:
           - 'basic_functional_group'
           - 'test_cases_group'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        continue-on-error: ${{ matrix.version == 'nightly' }}
+        env:
+          IIF_TEST_GROUP: ${{ matrix.group }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        if: ${{ matrix.version != 'nightly' }}
+
+  test-debug-group:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.group }}
+    runs-on: ${{ matrix.os }}
+    env:
+      JULIA_PKG_SERVER: ""
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.8'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        group:
           - 'tmp_debug_group'
     steps:
       - uses: actions/checkout@v2
@@ -49,18 +83,27 @@ jobs:
 
   upstream-dev:
     #if: github.ref != 'refs/heads/release**'
+    needs: [ test-debug-group ]
     name: Upstream Dev
     runs-on: ubuntu-latest
     env: 
       JULIA_PKG_SERVER: ""
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.8'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        group:
+          - 'basic_functional_group'
+          - 'test_cases_group'
     steps:
       - uses: actions/checkout@v2
-
       - uses: julia-actions/setup-julia@v1
-        with:
-          version: 1.7
-          arch: x64
-
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts
@@ -71,11 +114,9 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-
       - run: |
           git config --global user.name Tester
           git config --global user.email te@st.er
-      
       - name: Upstream Dev
         run: |
           julia --project=@. --check-bounds=yes -e 'using Pkg; Pkg.add(PackageSpec(name="ApproxManifoldProducts",rev="master"));'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,13 @@ jobs:
     needs: [ test-debug-group ]
     name: Upstream Dev
     runs-on: ubuntu-latest
-    arch: x64
     env: 
       JULIA_PKG_SERVER: ""
     strategy:
       fail-fast: false
       matrix:
+        arch: 
+          - x64
         version:
           - '1.8'
           - 'nightly'
@@ -99,6 +100,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{ matrix.version != 'nightly' }}
 
   test-debug-group:
-    name: Julia ${{ version }} - ${{ matrix.group }}
+    name: Julia 1.8 - ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
     arch: 'x64'
     version: '1.8'
@@ -63,13 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        continue-on-error: ${{ matrix.version == 'nightly' }}
         env:
           IIF_TEST_GROUP: ${{ matrix.group }}
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         version:
           - '1.6'
           - '1.8'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
   test-debug-group:
     name: Julia 1.8 - ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
-    arch: 'x64'
-    version: '1.8'
+    arch: x64
+    version: 1.8
     env:
       JULIA_PKG_SERVER: ""
     strategy:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ TEST_GROUP = get(ENV, "IIF_TEST_GROUP", "all")
 #...
 if TEST_GROUP in ["all", "tmp_debug_group"]
 include("testMultiHypo3Door.jl")
+include("priorusetest.jl")
 end
 
 if TEST_GROUP in ["all", "basic_functional_group"]
@@ -76,7 +77,6 @@ include("testEuclidDistance.jl")
 end
 
 if TEST_GROUP in ["all", "test_cases_group"]
-include("priorusetest.jl")
 include("testnullhypothesis.jl") 
 include("testVariousNSolveSize.jl")
 include("testExplicitMultihypo.jl")


### PR DESCRIPTION
The idea here is when developing the known stochastic tests still run and fail, which is annoying, but happens early so the CI work cycle is much faster.  The usual functional and numeric tests are now decoupled from the known issues group.