### PR TITLE
Refactor Mixture as direct Density and standardize sampling on FluxModelsDistributions to resemble <: Sampleable

### DIFF
--- a/IncrementalInference/src/Deprecated.jl
+++ b/IncrementalInference/src/Deprecated.jl
@@ -5,32 +5,32 @@
 #TODO this looks like dead code, should be removed
 # TODO deprecate testshuffle
 function _checkErrorCCWNumerics(
-  ccwl::Union{CommonConvWrapper{F}, CommonConvWrapper{Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   testshuffle::Bool = false,
-) where {N_, F <: AbstractRelativeMinimize, S, T}
+) where {F <: AbstractRelativeMinimize}
   return nothing
 end
 function _checkErrorCCWNumerics(
-  ccwl::Union{CommonConvWrapper{F}, CommonConvWrapper{Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   testshuffle::Bool = false,
-) where {N_, F <: AbstractManifoldMinimize, S, T}
+) where {F <: AbstractManifoldMinimize}
   return nothing
 end
 
 #TODO this looks like dead code, should be removed
 function _perturbIfNecessary(
-  fcttype::Union{F, <:Mixture{N_, F, S, T}},
+  fcttype::AbstractRelativeMinimize,
   len::Int = 1,
   perturbation::Real = 1e-10,
-) where {N_, F <: AbstractRelativeMinimize, S, T}
+)
   return 0
 end
 
 function _perturbIfNecessary(
-  fcttype::Union{F, <:Mixture{N_, F, S, T}},
+  fcttype::AbstractManifoldMinimize,
   len::Int = 1,
   perturbation::Real = 1e-10,
-) where {N_, F <: AbstractManifoldMinimize, S, T}
+)
   return 0
 end
 #
@@ -149,6 +149,10 @@ DFG.getDimension(fct::DFG.GenericFunctionNodeData) = _getZDim(fct)
 
 function resetData!(vdata::DFG.FunctionNodeData)
   error("resetData!(vdata::FunctionNodeData) is deprecated, use resetData!(state::FactorState) instead")
+end
+
+function sampleTangent(x::ManifoldKernelDensity, p = mean(x))
+  error("sampleTangent(x::ManifoldKernelDensity, p) should be replaced by sampleTangent(M<:AbstractManifold, x::ManifoldKernelDensity, p)")
 end
 
 ## ================================================================================================

--- a/IncrementalInference/src/Factors/LinearRelative.jl
+++ b/IncrementalInference/src/Factors/LinearRelative.jl
@@ -32,6 +32,7 @@ LinearRelative(nm::MvNormal) = LinearRelative{length(nm.μ), typeof(nm)}(nm)
 function LinearRelative(nm::Union{<:BallTreeDensity, <:ManifoldKernelDensity})
   return LinearRelative{Ndim(nm), typeof(nm)}(nm)
 end
+LinearRelative(z) = LinearRelative{length(z)}(z)
 
 getManifold(::InstanceType{LinearRelative{N}}) where {N} = getManifold(ContinuousEuclid{N})
 

--- a/IncrementalInference/src/Factors/Mixture.jl
+++ b/IncrementalInference/src/Factors/Mixture.jl
@@ -1,6 +1,3 @@
-
-_defaultNamesMixtures(N::Int) = ((Symbol[Symbol("c$i") for i = 1:N])...,)
-
 """
 $(TYPEDEF)
 
@@ -12,195 +9,77 @@ Notes
 - `N` is the number of components used to make the mixture, so two bumps from two Normal components means `N=2`.
 
 DevNotes
-- FIXME swap API order so Mixture of distibutions works like a distribtion, see Caesar.jl #808
-  - Should not have field mechanics.
 - TODO on sampling see #1099 and #1094 and #1069 
 
-
 Example
-```juila
+```julia
 # prior factor
-msp = Mixture(Prior, 
-              [Normal(0,0.1), Uniform(-pi/1,pi/2)],
-              [0.5;0.5])
+msp = Prior(Mixture([Normal(0,0.1), Uniform(-pi/1,pi/2)], [0.5;0.5])
 
 addFactor!(fg, [:head], msp, tags=[:MAGNETOMETER;])
 
 # Or relative
-mlr = Mixture(LinearRelative, 
+mlr = LinearRelative(Mixture(
               (correlator=AliasingScalarSampler(...), naive=Normal(0.5,5), lucky=Uniform(0,10)),
-              [0.5;0.4;0.1])
+              [0.5;0.4;0.1]
+      )
 
 addFactor!(fg, [:x0;:x1], mlr)
 ```
 """
-struct Mixture{N, F <: AbstractObservation, S, T <: Tuple} <: AbstractObservation
-  """ factor mechanics """
-  mechanics::F
-  components::NamedTuple{S, T}
-  diversity::Distributions.Categorical
-  """ dimension of factor, so range measurement would be dims=1 """
-  dims::Int
-  labels::Vector{Int}
+# we can do <: Sampleable{VF, VS}, but then all components must implement Sampleable
+struct Mixture{C <: NamedTuple, P <: Categorical}
+    components::C
+    prior::P
 end
 
+Base.length(d::Mixture) = length(d.components[1])
+#FIXME next not working
+# Base.rand(rng::AbstractRNG, d::Mixture) = rand(rng, d.components[rand(rng, d.prior)])
+Base.rand(d::Mixture) = rand(d.components[rand(d.prior)])
+getDimension(p::Mixture) = length(p)
+
+Mixture(z::NamedTuple) = Mixture(z, Categorical(length(z)))
+Mixture(z::NamedTuple, c::Union{<:Tuple, <:AbstractVector}) = Mixture(z, Categorical(c))
+
 function Mixture(
-  f::Type{F},
-  z::NamedTuple{S, T},
-  c::Distributions.DiscreteNonParametric,
-) where {F <: AbstractObservation, S, T}
-  return Mixture{length(z), F, S, T}(
-    f(LinearAlgebra.I),
-    z,
-    c,
-    size(rand(z[1], 1), 1),
-    zeros(Int, 0),
+    z::Union{<:Tuple, <:AbstractVector},
+    args...,
+)
+    cnames = tuple((Symbol("c", i) for i = 1:length(z))...)
+    return Mixture(NamedTuple{cnames}(z), args...)
+end
+
+function Mixture(f::Type{<:AbstractObservation}, args...)
+    return f(Mixture(args...))
+end
+
+Base.@kwdef struct PackedMixture{C} <: PackedBelief
+  _type::String = "IncrementalInference.PackedMixture"
+  components::C
+  prior::PackedCategorical
+end
+
+# FIXME 🦨 use JSON properly (in JSONv1 upgrade)
+function PackedMixture(_type::String, comp_obj::JSON3.Object, prior_obj::JSON3.Object) 
+  PackedMixture(
+    _type,
+    NamedTuple(map(c -> c[1]=>convert(PackedBelief, c[2]), collect(pairs(comp_obj)))),
+    PackedCategorical(; prior_obj...),
   )
 end
-function Mixture(
-  f::F,
-  z::NamedTuple{S, T},
-  c::Distributions.DiscreteNonParametric,
-) where {F <: AbstractObservation, S, T}
-  return Mixture{length(z), F, S, T}(f, z, c, size(rand(z[1], 1), 1), zeros(Int, 0))
-end
-function Mixture(
-  f::Union{F, Type{F}},
-  z::NamedTuple{S, T},
-  c::AbstractVector{<:Real},
-) where {F <: AbstractObservation, S, T}
-  return Mixture(f, z, Categorical([c...]))
-end
-function Mixture(
-  f::Union{F, Type{F}},
-  z::NamedTuple{S, T},
-  c::NTuple{N, <:Real},
-) where {N, F <: AbstractObservation, S, T}
-  return Mixture(f, z, [c...])
-end
-function Mixture(
-  f::Union{F, Type{F}},
-  z::Tuple,
-  c::Union{
-    <:Distributions.DiscreteNonParametric,
-    <:AbstractVector{<:Real},
-    <:NTuple{N, <:Real},
-  },
-) where {F <: AbstractObservation, N}
-  return Mixture(f, NamedTuple{_defaultNamesMixtures(length(z))}(z), c)
-end
-function Mixture(
-  f::Union{F, Type{F}},
-  z::AbstractVector{<:SamplableBelief},
-  c::Union{
-    <:Distributions.DiscreteNonParametric,
-    <:AbstractVector{<:Real},
-    <:NTuple{N, <:Real},
-  },
-) where {F <: AbstractObservation, N}
-  return Mixture(f, (z...,), c)
-end
 
-function Base.resize!(mp::Mixture, s::Int)
-  return resize!(mp.labels, s)
-end
 
-_lengthOrNothing(val) = length(val)
-_lengthOrNothing(val::Nothing) = 0
-
-getManifold(m::Mixture) = getManifold(m.mechanics)
-
-# TODO make in-place memory version
-function sampleFactor(cf::CalcFactor{<:Mixture}, N::Int = 1)
-  #
-  # TODO consolidate #927, case if mechanics has a special sampler
-  # TODO slight bit of waste in computation, but easiest way to ensure special tricks in s.mechanics::F are included
-  ## example case is old FluxModelsPose2Pose2 requiring velocity
-  # FIXME better consolidation of when to pass down .mechanics, also see #1099 and #1094 and #1069
-
-  cf_ = CalcFactorNormSq(
-    cf.factor.mechanics,
-    0,
-    cf._legacyParams,
-    cf._allowThreads,
-    cf.cache,
-    cf.fullvariables,
-    cf.solvefor,
-    cf.manifold,
-    cf.measurement,
-    nothing,
+function DFG.packDistribution(m::Mixture)
+  PackedMixture(;
+    components = map(packDistribution, m.components),
+    prior = PackedCategorical(; p = m.prior.p)
   )
-  smpls = [getSample(cf_) for _ = 1:N]
-  # smpls = Array{Float64,2}(undef,s.dims,N)
-  #out memory should be right size first
-  length(cf.factor.labels) != N ? resize!(cf.factor.labels, N) : nothing
-  cf.factor.labels .= rand(cf.factor.diversity, N)
-  M = cf.manifold
-  
-  # mixture needs to be refactored so let's make it worse :-)
-  if cf.factor.mechanics isa AbstractPriorObservation
-    samplef = samplePoint
-  elseif cf.factor.mechanics isa AbstractRelativeObservation
-    samplef = sampleTangent
-  end
-
-  for i = 1:N
-    mixComponent = cf.factor.components[cf.factor.labels[i]]
-    # measurements relate to the factor's manifold (either tangent vector or manifold point)
-    setPointsMani!(smpls,  samplef(M, mixComponent), i)
-  end
-
-  # TODO only does first element of meas::Tuple at this stage, see #1099
-  return smpls
 end
 
-function DistributedFactorGraphs.isPrior(::Type{Mixture{N, F, S, T}}) where {N, F, S, T}
-  return F <: AbstractPriorObservation
+function DFG.unpackDistribution(pm::PackedMixture)
+  Mixture(
+    map(unpackDistribution, pm.components),
+    unpackDistribution(pm.prior)
+  )
 end
-
-"""
-$(TYPEDEF)
-
-Serialization type for `Mixture`.
-"""
-Base.@kwdef mutable struct PackedMixture <: AbstractPackedObservation
-  N::Int
-  # store the packed type for later unpacking
-  F_::String
-  S::Vector{String}
-  components::Vector{PackedBelief}
-  diversity::PackedBelief
-end
-
-function convert(::Type{<:PackedMixture}, obj::Mixture{N, F, S, T}) where {N, F, S, T}
-  allcomp = PackedBelief[]
-  for val in obj.components
-    dtr_ = convert(PackedBelief, val)
-    # FIXME ON FIRE, likely to be difficult for non-standard "Samplable" types -- e.g. Flux models in RoME
-    push!(allcomp, dtr_)
-  end
-  if hasmethod(pack, (typeof(obj.mechanics),))
-    pm = pack(obj.mechanics)
-  else
-    @warn("No pack method for mechanics type $(typeof(obj.mechanics)), using deprecated convert instead.")
-    pm = convert(DFG.convertPackedType(obj.mechanics), obj.mechanics)
-  end
-  sT = string(typeof(pm))
-  dvst = convert(PackedBelief, obj.diversity)
-  return PackedMixture(N, sT, string.(collect(S)), allcomp, dvst)
-end
-
-function convert(::Type{<:Mixture}, obj::PackedMixture)
-  N = obj.N
-  F1 = getfield(Main, Symbol(obj.F_))
-  S = (Symbol.(obj.S)...,)
-  F2 = DFG.convertStructType(F1)
-
-  components = map(c -> convert(SamplableBelief, c), obj.components)
-  diversity = convert(SamplableBelief, obj.diversity)
-  # tupcomp = (components...,)
-  ntup = NamedTuple{S}(components) # ,typeof(tupcomp)
-  return Mixture(F2, ntup, diversity)
-end
-
-#

--- a/IncrementalInference/src/Factors/PartialPrior.jl
+++ b/IncrementalInference/src/Factors/PartialPrior.jl
@@ -15,6 +15,7 @@ struct PartialPrior{T <: SamplableBelief, P <: Tuple} <: AbstractPriorObservatio
 end
 
 # TODO, standardize, but shows error on testPartialNH.jl
+#FIXME should call samplePoint(M, cf.factor.Z)
 getSample(cf::CalcFactor{<:PartialPrior}) = samplePoint(cf.factor.Z)   # remove in favor of ManifoldSampling.jl
 # getManifold(pp::PartialPrior) = TranslationGroup(length(pp.partial)) # uncomment
 

--- a/IncrementalInference/src/IncrementalInference.jl
+++ b/IncrementalInference/src/IncrementalInference.jl
@@ -169,6 +169,7 @@ include("Factors/GenericMarginal.jl")
 include("entities/AliasScalarSampling.jl")
 include("entities/ExtDensities.jl") # used in BeliefTypes.jl::SamplableBeliefs
 include("entities/ExtFactors.jl")
+include("Factors/Mixture.jl")
 include("entities/BeliefTypes.jl")
 
 include("services/HypoRecipe.jl")
@@ -218,7 +219,6 @@ include("Variables/DefaultVariables.jl")
 
 # included factors, see RoME.jl for more examples
 include("Factors/GenericFunctions.jl")
-include("Factors/Mixture.jl")
 include("Factors/DefaultPrior.jl")
 include("Factors/LinearRelative.jl")
 include("Factors/EuclidDistance.jl")

--- a/IncrementalInference/src/entities/BeliefTypes.jl
+++ b/IncrementalInference/src/entities/BeliefTypes.jl
@@ -18,6 +18,7 @@ struct ParametricMessage <: MessageType end
 
 using DistributedFactorGraphs: PackedBelief
 
+#TODO deprecate SamplableBelief
 const SamplableBelief = Union{
   <:Distributions.Distribution,
   <:KDE.BallTreeDensity, # FIXME deprecate
@@ -26,6 +27,7 @@ const SamplableBelief = Union{
   <:FluxModelsDistribution,
   <:HeatmapGridDensity,
   <:LevelSetGridNormal,
+  <:Mixture,
 }
 
 #Supported types for parametric

--- a/IncrementalInference/src/manifolds/services/ManifoldSampling.jl
+++ b/IncrementalInference/src/manifolds/services/ManifoldSampling.jl
@@ -9,10 +9,6 @@ Notes
 """
 function sampleTangent end
 
-function sampleTangent(x::ManifoldKernelDensity, p = mean(x))
-  error("sampleTangent(x::ManifoldKernelDensity, p) should be replaced by sampleTangent(M<:AbstractManifold, x::ManifoldKernelDensity, p)")
-end
-
 # Sampling Distributions
 # assumes M is a group and will break for Riemannian, but leaving that enhancement as TODO
 function sampleTangent(
@@ -32,13 +28,6 @@ function sampleTangent(M::typeof(LieGroups.CircleGroup()), z::Distribution, p = 
   return hat(LieAlgebra(M), rand(z))
 end
 
-function sampleTangent(M::AbstractLieGroup, x::ManifoldKernelDensity, p = mean(x))
-  # get legacy matrix of coordinates and selected labels
-  #TODO make sure that when `sample` is replaced in MKD, coordinates is a vector
-  coords, lbls = sample(x.belief, 1)
-  X = hat(LieAlgebra(M), coords[:], typeof(p))
-  return X
-end
 
 """
     $SIGNATURES

--- a/IncrementalInference/src/parametric/services/ParametricManopt.jl
+++ b/IncrementalInference/src/parametric/services/ParametricManopt.jl
@@ -37,7 +37,7 @@ function CalcFactorResidual(
 
   return CalcFactorResidual(
     fct.label,
-    getFactorMechanics(fac_func),
+    fac_func,
     tuple(varOrder...),
     tuple(varOrderIdxs...),
     meas,

--- a/IncrementalInference/src/parametric/services/ParametricUtils.jl
+++ b/IncrementalInference/src/parametric/services/ParametricUtils.jl
@@ -133,10 +133,6 @@ getFactorMeasurementParametric(dfg::AbstractDFG, flb::Symbol) = getFactorMeasure
 ## Parametric solve with Mahalanobis distance - CalcFactor
 ## ================================================================================================
 
-#TODO maybe remove with Mixture rework see #1504
-getFactorMechanics(f::AbstractObservation) = f
-getFactorMechanics(f::Mixture) = f.mechanics
-
 function CalcFactorMahalanobis(fg, fct::FactorCompute)
   fac_func = getFactorType(fct)
   varOrder = getVariableOrder(fct)
@@ -164,7 +160,7 @@ function CalcFactorMahalanobis(fg, fct::FactorCompute)
     special = nothing
   end
 
-  return CalcFactorMahalanobis(fct.label, getFactorMechanics(fac_func), cache, varOrder, meas, iΣ, special)
+  return CalcFactorMahalanobis(fct.label, fac_func, cache, varOrder, meas, iΣ, special)
 end
 
 # This is where the actual parametric calculation happens, CalcFactor equivalent for parametric

--- a/IncrementalInference/src/services/CalcFactor.jl
+++ b/IncrementalInference/src/services/CalcFactor.jl
@@ -283,13 +283,10 @@ end
 Internal method to set which dimensions should be used as the decision variables for later numerical optimization.
 """
 function _setCCWDecisionDimsConv!(
-  ccwl::Union{CommonConvWrapper{F}, CommonConvWrapper{Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   xDim::Int
 ) where {
-  N_,
   F <: AbstractObservation,
-  S,
-  T,
 }
   #
 
@@ -616,27 +613,14 @@ function _beforeSolveCCW!(
   return maxlen
 end
 
-# TODO, can likely deprecate this
 function _beforeSolveCCW!(
-  ccwl::Union{CommonConvWrapper{F}, CommonConvWrapper{Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   Xi::AbstractVector{<:VariableCompute},
   # destVarVals::AbstractVector,
   sfidx::Int,
   N::Integer;
   kw...,
-) where {N_, F <: AbstractRelativeObservation, S, T}
-  #
-  return _beforeSolveCCW!(F, ccwl, Xi, sfidx, N; kw...)
-end
-
-function _beforeSolveCCW!(
-  ccwl::Union{CommonConvWrapper{F}, CommonConvWrapper{Mixture{N_, F, S, T}}},
-  Xi::AbstractVector{<:VariableCompute},
-  # destVarVals::AbstractVector,
-  sfidx::Int,
-  N::Integer;
-  kw...,
-) where {N_, F <: AbstractPriorObservation, S, T}
+) where {F}
   #
   return _beforeSolveCCW!(F, ccwl, Xi, sfidx, N; kw...)
 end

--- a/IncrementalInference/src/services/EvalFactor.jl
+++ b/IncrementalInference/src/services/EvalFactor.jl
@@ -13,11 +13,11 @@ Future work:
 """
 function approxConvOnElements!(
   destVarVals::AbstractArray,
-  ccwl::Union{CommonConvWrapper{F}, CommonConvWrapper{Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   elements::Union{Vector{Int}, UnitRange{Int}},
   # ::Type{<:SingleThreaded},
   _slack = nothing,
-) where {N_, F <: AbstractRelativeObservation, S, T}
+) where {F <: AbstractRelativeObservation}
   #
   for n in elements
     ccwl.particleidx[] = n
@@ -143,7 +143,7 @@ DevNotes
 - Future combo with `_calcIPCRelative`
 """
 function computeAcrossHypothesis!(
-  ccwl::Union{<:CommonConvWrapper{F}, <:CommonConvWrapper{Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   hyporecipe::HypoRecipe, #NamedTuple,
   sfidx::Int,
   maxlen::Int,
@@ -154,7 +154,7 @@ function computeAcrossHypothesis!(
   skipSolve::Bool = false,
   testshuffle::Bool = false,
   _slack = nothing,
-) where {N_, F <: AbstractRelativeObservation, S, T}
+) where {F <: AbstractRelativeObservation}
   #
   count = 0
   # transition to new hyporecipe approach
@@ -541,17 +541,6 @@ function evalPotentialSpecific(
 
   # check partial is easy as this is a prior
   return addEntr, ipc
-end
-
-function evalPotentialSpecific(
-  Xi::AbstractVector{<:VariableCompute},
-  ccwl::CommonConvWrapper{Mixture{N_, F, S, T}},
-  solvefor::Symbol,
-  measurement::AbstractVector = Tuple[];
-  kw...,
-) where {N_, F <: AbstractObservation, S, T}
-  #
-  return evalPotentialSpecific(Xi, ccwl, solvefor, F, measurement; kw...)
 end
 
 function evalPotentialSpecific(

--- a/IncrementalInference/src/services/MaxMixture.jl
+++ b/IncrementalInference/src/services/MaxMixture.jl
@@ -11,7 +11,7 @@ struct MaxMixture <: AbstractMaxMixtureSolver
   choice::Base.RefValue{Int}
 end
 
-function getMeasurementParametric(s::Mixture{N, F, S, T}) where {N, F, S, T}
+function getMeasurementParametric(s::Mixture)
   meas = map(c -> getMeasurementParametric(c)[1], values(s.components))
   iΣ = map(c -> getMeasurementParametric(c)[2], values(s.components))
   return meas, iΣ

--- a/IncrementalInference/src/services/NumericalCalculations.jl
+++ b/IncrementalInference/src/services/NumericalCalculations.jl
@@ -45,11 +45,8 @@ You can overload this method for your custom factor type to specify a different 
 - Overload this trait for your custom factor if you require a different solver for approxConv.
 - The solver determines which optimization backend and method will be used during inference.
 """
-ConvSolver(::Union{<:RelativeObservation, <:Mixture{N, <:RelativeObservation}}) where {N} = LieGroupOptimConvSolver()
-
-function ConvSolver(::Union{F, <:Mixture{N_, F, S, T}}) where {N_, F <: AbstractRelativeMinimize, S, T}
-  OptimConvSolver()
-end
+ConvSolver(::RelativeObservation) = LieGroupOptimConvSolver()
+ConvSolver(::AbstractRelativeMinimize) = OptimConvSolver()
 
 ## ================================================================================================
 function _solveLambdaNumeric(
@@ -312,10 +309,10 @@ DevNotes
 - TODO perhaps consolidate perturbation with inflation or nullhypo
 """
 function _solveCCWNumeric!(
-  ccwl::Union{<:CommonConvWrapper{F}, <:CommonConvWrapper{<:Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   _slack = nothing;
   perturb::Real = 1e-10,
-) where {N_, F <: AbstractRelativeMinimize, S, T}
+) where {F <: AbstractRelativeMinimize}
   #
   
   #
@@ -454,10 +451,10 @@ function _buildHypoCalcFactor(ccwl::CommonConvWrapper, smpid::Integer, _slack=no
 end
 
 function _solveCCWNumeric!(
-  ccwl::Union{<:CommonConvWrapper{F}, <:CommonConvWrapper{<:Mixture{N_, F, S, T}}},
+  ccwl::CommonConvWrapper{F},
   _slack = nothing;
   perturb::Real = 1e-10,
-) where {N_, F <: RelativeObservation, S, T}
+) where {F <: RelativeObservation}
   #
   #   # FIXME, move this check higher and out of smpid loop
   # _checkErrorCCWNumerics(ccwl, testshuffle)

--- a/IncrementalInference/test/testFluxModelsDistribution.jl
+++ b/IncrementalInference/test/testFluxModelsDistribution.jl
@@ -15,7 +15,7 @@ fxd = FluxModelsDistribution((5,),(3,),mdls,rand(5), false, false)
 
 # check sampler is working
 measd = rand(fxd, 2)
-@test length( measd ) == 2
+@test size( measd ) == (3,2)
 
 # convert to packed type
 fxp = convert(PackedBelief, fxd) # TODO, PackedBelief
@@ -50,7 +50,7 @@ addFactor!(fg, [:x0;], pr)
 ##
 
 smpls = sampleFactor(fg, :x0f1, 10)
-@test eltype(smpls) <: Vector{<:Real}
+@test eltype(smpls) <: AbstractVector{<:Real}
 @test smpls isa Vector #{Vector{Float64}}
 @test length( smpls ) == 10
 
@@ -119,7 +119,7 @@ pts_ = getBelief(fg, :x1) |> getPoints
 
 # will predict from existing fg
 f1 = getFactorType(fg, :x0x1f1)
-predictions = map(f->f(f1.components.nn.data), f1.components.nn.models)
+predictions = map(f->f(f1.Z.components.nn.data), f1.Z.components.nn.models)
 
 
 # unpack into new fg_
@@ -127,13 +127,13 @@ fg_ = loadDFG("/tmp/fg_test_flux")
 
 # same predictions with deserialized object
 f1_ = getFactorType(fg_, :x0x1f1)
-predictions_ = map(f->f(f1_.components.nn.data), f1_.components.nn.models)
+predictions_ = map(f->f(f1_.Z.components.nn.data), f1_.Z.components.nn.models)
 
 # check that all predictions line up
 @show norm(predictions - predictions_)
 @test norm(predictions - predictions_) < 1e-6
 
-f1_.components.nn.shuffle[] = true
+f1_.Z.components.nn.shuffle[] = true
 
 # test solving of the new object
 solveTree!(fg_);

--- a/IncrementalInference/test/testMixtureLinearConditional.jl
+++ b/IncrementalInference/test/testMixtureLinearConditional.jl
@@ -19,7 +19,7 @@ using TensorCast
 fg = initfg()
 addVariable!(fg, :x0, ContinuousScalar)
 
-mp = Mixture(Prior, (Normal(), Normal(10,1)),(1/2,1/2) )
+mp = Mixture(Prior, (Normal(), Normal(10,1)),[1/2,1/2] )
 addFactor!(fg, [:x0], mp)
 
 ##
@@ -49,7 +49,7 @@ addVariable!(fg, :x1, ContinuousScalar)
 addFactor!(fg, [:x0], Prior(Normal()), graphinit=false)
 initVariable!(fg, :x0, [zeros(1) for _ in 1:100])
 
-mlr = Mixture(LinearRelative, (Normal(), Normal(10,1)),(1/2,1/2) )
+mlr = Mixture(LinearRelative, (Normal(), Normal(10,1)), [1/2,1/2])
 addFactor!(fg, [:x0;:x1], mlr, graphinit=false)
 
 ##
@@ -118,13 +118,13 @@ rebuildFactorCache!(fg_, f1_)
 @show typeof(DFG.getCache(f1).varValsAll[]);
 @show typeof(DFG.getCache(f1_).varValsAll[]);
 
-@test DFG.compareFactor(f1, f1_, skip=[:components;:labels;:timezone;:zone;:vartypes;:fullvariables;:particleidx;:varidx])
+@test DFG.compareFactor(f1, f1_, skip=[:Z;:components;:labels;:timezone;:zone;:vartypes;:fullvariables;:particleidx;:varidx])
 
-@test IIF._getCCW(f1).usrfnc!.components.naive == IIF._getCCW(f1).usrfnc!.components.naive
+@test IIF._getCCW(f1).usrfnc!.Z.components.naive == IIF._getCCW(f1).usrfnc!.Z.components.naive
 
 # already ManifoldKernelDensity
-A = IIF._getCCW(f1).usrfnc!.components.fancy
-B = IIF._getCCW(f1_).usrfnc!.components.fancy
+A = IIF._getCCW(f1).usrfnc!.Z.components.fancy
+B = IIF._getCCW(f1_).usrfnc!.Z.components.fancy
 
 # A = ManifoldBelief(Euclid, IIF._getCCW(f1).usrfnc!.components.fancy )
 # B = ManifoldBelief(Euclid, IIF._getCCW(f1_).usrfnc!.components.fancy )
@@ -149,15 +149,14 @@ addFactor!(fg, [:x0], Prior(Normal(0.0,0.1)))
 ##
 
 # require default ::UnitScaling constructor from all factors
-mlr = Mixture(LinearRelative(I), [Normal(-1.0, 0.1), Normal(1.0, 0.1)], Categorical([0.5; 0.5]))
+mlr = Mixture(LinearRelative, [Normal(-1.0, 0.1), Normal(1.0, 0.1)], Categorical([0.5; 0.5]))
 
 # test serialization while we are here
-pmlr = convert(PackedMixture, mlr)
-umlr = convert(Mixture, pmlr)
+pmlr = DFG.pack(mlr)
+umlr = DFG.unpack(pmlr)
 
-@test mlr.mechanics == umlr.mechanics
-@test mlr.components == umlr.components
-@test mlr.diversity == umlr.diversity
+@test mlr.Z.components == umlr.Z.components
+@test mlr.Z.prior == umlr.Z.prior
 
 mlr = Mixture(LinearRelative, [Normal(-1.0, 0.1), Normal(1.0, 0.1)], Categorical([0.5; 0.5]))
 

--- a/IncrementalInference/test/testMixturePrior.jl
+++ b/IncrementalInference/test/testMixturePrior.jl
@@ -27,9 +27,9 @@ bss = AliasingScalarSampler(collect(1:50), v)
 
 
 # add bi-modal mixture prior
-Prior0 = Mixture(Prior,(a=Normal(-5.0,1.0), b=Uniform(0.0,1.0)), (0.5,0.5))
-Prior0 = Mixture(Prior,(Normal(-5.0,1.0), Normal(0.0,1.0)), (0.5,0.5))
-Prior0 = Mixture(Prior,[Normal(-5.0,1.0), Normal(0.0,1.0)], (0.5,0.5))
+Prior0 = Mixture(Prior,(a=Normal(-5.0,1.0), b=Uniform(0.0,1.0)), [0.5,0.5])
+Prior0 = Mixture(Prior,(Normal(-5.0,1.0), Normal(0.0,1.0)), [0.5,0.5])
+Prior0 = Mixture(Prior,[Normal(-5.0,1.0), Normal(0.0,1.0)], [0.5,0.5])
 Prior0 = Mixture(Prior,(Normal(-5.0,1.0), Normal(0.0,1.0)), [0.5;0.5])
 Prior0 = Mixture(Prior,[Normal(-5.0,1.0), Normal(0.0,1.0)], [0.5;0.5])
 Prior0 = Mixture(Prior,(Normal(-5.0,1.0), bss), Categorical([0.5;0.5]))

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ Alternatively, either use the Github Blame, or the Github `/compare/v0.18.0...v0
 
 The list below highlights breaking changes according to normal semver workflow -- i.e. breaking changes go through at least one deprecatation (via warnings) on the dominant number in the version number.  E.g. v0.18 -> v0.19 (warnings) -> v0.20 (breaking).  Note that ongoing efforts are made to properly deprecate old code/APIs
 
+# Changes in v0.36
+- Refactor Mixture as direct Density see #1420
+- Standardize sampling on FluxModelsDistributions
+
 # Changes in v0.35
 
 - Standardize toward Manopt.jl (currently Riemannian Levenberg-Marquart), still have Optim.jl legacy support (#1784, #1778).


### PR DESCRIPTION
Needs: https://github.com/JuliaRobotics/ApproxManifoldProducts.jl/pull/320

Close #1420

Note: 
- Sampleable beliefs need to work the same as <: Sampleable
- Only somewhat breaking, but mostly kept the Mixture signature. 